### PR TITLE
kselftests: validate the supported kernel syscall subsets

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -93,7 +93,9 @@ lib.makeScope (scope: lib.callPackageWith ({ inherit lib pkgs; } // scope)) (
     # The private guest protocol and its JavaScript SDK ship together.
     guest-agent = callPackage ./guest-agent/package.nix { };
     ltp = callPackage ./ltp/package.nix { };
+    kselftests = callPackage ./kselftests/package.nix { };
 
+    # host tools and tests:
     node-workspace = callPackage ./node-workspace.nix { };
     linux-guest = callPackage ./linux-guest { };
     runner = callPackage ./runner { };

--- a/packages/kselftests/package.nix
+++ b/packages/kselftests/package.nix
@@ -1,0 +1,117 @@
+{
+  pkgs,
+  lib,
+  stdenv,
+  src ? pkgs.fetchFromGitHub {
+    owner = "tombl";
+    repo = "linux";
+    rev = "cc1bf87e3e277d506aa7372dacab29d8455aac6b";
+    hash = "sha256-qqAwmfv7h8+6dfdBksun7wr+QQ+G/3lhg8CPW1Aq90c=";
+  },
+  linux,
+  busybox,
+  vm-test,
+}:
+
+# The kselftest syscall suites, built against the same kernel source the running
+# kernel comes from. Each suite is a self-contained pair under suites/: a
+# <name>.nix descriptor and a <name>-test.sh guest script. A suite is anything
+# with a .nix here, discovered by readDir, so adding one means dropping two files
+# in suites/ (and git add-ing them so the flake sees them) — no registration
+# line to edit and collide on. Shared logic — the wasm build recipe, the patches
+# applied once to the selftests tree, and the VM check wiring — lives here so the
+# suite files stay pure data.
+#
+# clone3/raw-clone tests are skipped on principle across every suite: the wasm
+# clone syscall takes a custom fn/fn_arg ABI, not the generic stack-based one, so
+# the generic clone path does not apply. Tests going through musl's clone()
+# wrapper (which speaks the wasm ABI) are run deliberately.
+
+let
+  suffixed =
+    dir: suffix:
+    map (name: dir + "/${name}") (
+      lib.filter (lib.hasSuffix suffix) (builtins.attrNames (builtins.readDir dir))
+    );
+
+  suites = lib.listToAttrs (
+    map (path: lib.nameValuePair (lib.removeSuffix ".nix" (baseNameOf path)) (import path)) (
+      suffixed ./suites ".nix"
+    )
+  );
+
+  # Patches are shared because suites share headers (kselftest.h, futex logging)
+  # and each patch touches a disjoint file, so the apply order does not matter.
+  patches = suffixed ./patches ".patch";
+
+  # A discovered suite is real test coverage, not a boot-only placeholder.
+  checkedSuites = lib.mapAttrs (
+    name: suite:
+    assert lib.assertMsg (suite.binaries != [ ]) "kselftest suite ${name} has no binaries";
+    suite
+  ) suites;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kselftests";
+  inherit (linux) version;
+  inherit src patches;
+
+  # lib.mk force-sets CC from LLVM/CROSS_COMPILE, but a make command-line
+  # assignment wins; passing the wasm cc-wrapper as CC sidesteps lib.mk's missing
+  # CLANG_TARGET_FLAGS_wasm entry entirely. This kernel's installed uapi headers
+  # go in through two doors: KHDR_INCLUDES for the suites whose Makefiles wire it,
+  # and USERCFLAGS (lib.mk's documented CFLAGS extension) so suites that don't
+  # (e.g. openat2) still find linux/*.h. lib.mk's own default of
+  # -isystem $(top_srcdir)/usr/include points at a dir nothing populates here.
+  buildPhase = ''
+    runHook preBuild
+    ${lib.concatStrings (
+      lib.mapAttrsToList (_name: suite: ''
+        make -C ${suite.dir} \
+          OUTPUT=. \
+          CC="$CC" \
+          KHDR_INCLUDES="-isystem ${linux.headers}/include" \
+          USERCFLAGS="-isystem ${linux.headers}/include" \
+          ${toString (suite.makeFlags or [ ])} \
+          ${lib.concatMapStringsSep " " (binary: "./${binary}") suite.binaries}
+      '') checkedSuites
+    )}
+    runHook postBuild
+  '';
+
+  # Binaries are namespaced per suite because names collide across the tree
+  # (every suite has its own test binary, some share helper names).
+  installPhase = ''
+    runHook preInstall
+    ${lib.concatStrings (
+      lib.mapAttrsToList (name: suite: ''
+        mkdir -p $out/${name}
+        ${lib.concatMapStrings (b: "cp ${suite.dir}/${b} $out/${name}/\n") suite.binaries}
+      '') checkedSuites
+    )}
+    runHook postInstall
+  '';
+
+  passthru.checks = lib.mapAttrs (
+    name: suite:
+    let
+      # Explicit per-binary copies avoid accidentally adding helper binaries to
+      # the guest image when a suite's Makefile grows new targets upstream.
+      suiteBin = pkgs.runCommand "kselftests-${name}-bin" { } ''
+        mkdir -p $out/bin
+        ${lib.concatMapStrings (b: "cp ${finalAttrs.finalPackage}/${name}/${b} $out/bin/\n") suite.binaries}
+      '';
+    in
+    vm-test.vmTest {
+      name = "kselftests-${name}";
+      initramfs = vm-test.mkInitramfs {
+        name = "kselftests-${name}";
+        init = suite.run;
+        contents = [
+          busybox
+          suiteBin
+        ];
+      };
+    }
+  ) checkedSuites;
+})

--- a/packages/kselftests/patches/futex-basename-libgen.patch
+++ b/packages/kselftests/patches/futex-basename-libgen.patch
@@ -1,0 +1,17 @@
+Every futex/functional test calls basename() from its usage()/main. glibc
+declares basename() in <string.h> under _GNU_SOURCE, but musl only provides the
+POSIX basename() in <libgen.h>, so the tests fail to compile against musl with
+an implicit-declaration error. Include <libgen.h> from the shared logging
+header, which every test already includes and which advertises itself as the
+"glibc independent" futex helper.
+
+--- a/tools/testing/selftests/futex/include/logging.h
++++ b/tools/testing/selftests/futex/include/logging.h
+@@ -17,6 +17,7 @@
+ #ifndef _LOGGING_H
+ #define _LOGGING_H
+
++#include <libgen.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>

--- a/packages/kselftests/patches/kcmp-use-libc-clone.patch
+++ b/packages/kselftests/patches/kcmp-use-libc-clone.patch
@@ -1,0 +1,228 @@
+kcmp_test uses fork(), which musl intentionally does not expose on wasm. Port
+the test to libc clone() with SIGCHLD and no sharing flags: this exercises the
+wasm fn/fn_arg clone ABI while retaining the original fork-like process
+semantics. Propagate the child's result so failures are visible to the guest
+runner. This is wasm-port specific rather than generally upstreamable.
+
+--- a/tools/testing/selftests/kcmp/kcmp_test.c
++++ b/tools/testing/selftests/kcmp/kcmp_test.c
+@@ -5,6 +5,7 @@
+ #include <stdlib.h>
+ #include <signal.h>
+ #include <limits.h>
++#include <sched.h>
+ #include <unistd.h>
+ #include <errno.h>
+ #include <string.h>
+@@ -27,14 +28,103 @@
+ 
+ static const unsigned int duped_num = 64;
+ 
+-int main(int argc, char **argv)
++struct child_args {
++	int parent_pid;
++	int parent_fd;
++	int pipe_write_fd;
++	int epoll_fd;
++};
++
++static int run_child(void *opaque)
+ {
+ 	const char kpath[] = "kcmp-test-file";
++	const struct child_args *args = opaque;
+ 	struct kcmp_epoll_slot epoll_slot;
++	int child_pid = getpid();
++	int fd2;
++	int ret;
++
++	ksft_print_header();
++	ksft_set_plan(3);
++
++	fd2 = open(kpath, O_RDWR);
++	if (fd2 < 0) {
++		perror("Can't open file");
++		ksft_exit_fail();
++	}
++
++	/* An example of output and arguments */
++	printf("pid1: %6d pid2: %6d FD: %2ld FILES: %2ld VM: %2ld "
++	       "FS: %2ld SIGHAND: %2ld IO: %2ld SYSVSEM: %2ld "
++	       "INV: %2ld\n",
++	       args->parent_pid, child_pid,
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_FILE,
++			args->parent_fd, fd2),
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_FILES, 0, 0),
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_VM, 0, 0),
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_FS, 0, 0),
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_SIGHAND, 0, 0),
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_IO, 0, 0),
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_SYSVSEM, 0, 0),
++
++	       /* This one should fail */
++	       sys_kcmp(args->parent_pid, child_pid, KCMP_TYPES + 1, 0, 0));
++
++	/* This one should return same fd */
++	ret = sys_kcmp(args->parent_pid, child_pid, KCMP_FILE,
++		       args->parent_fd, args->parent_fd);
++	if (ret) {
++		printf("FAIL: 0 expected but %d returned (%s)\n",
++			ret, strerror(errno));
++		ksft_inc_fail_cnt();
++		ret = -1;
++	} else {
++		printf("PASS: 0 returned as expected\n");
++		ksft_inc_pass_cnt();
++	}
++
++	/* Compare with self */
++	ret = sys_kcmp(args->parent_pid, args->parent_pid, KCMP_VM, 0, 0);
++	if (ret) {
++		printf("FAIL: 0 expected but %d returned (%s)\n",
++			ret, strerror(errno));
++		ksft_inc_fail_cnt();
++		ret = -1;
++	} else {
++		printf("PASS: 0 returned as expected\n");
++		ksft_inc_pass_cnt();
++	}
++
++	/* Compare epoll target */
++	epoll_slot = (struct kcmp_epoll_slot) {
++		.efd	= args->epoll_fd,
++		.tfd	= duped_num,
++		.toff	= 0,
++	};
++	ret = sys_kcmp(args->parent_pid, args->parent_pid, KCMP_EPOLL_TFD,
++		       args->pipe_write_fd, (unsigned long)(void *)&epoll_slot);
++	if (ret) {
++		printf("FAIL: 0 expected but %d returned (%s)\n",
++			ret, strerror(errno));
++		ksft_inc_fail_cnt();
++		ret = -1;
++	} else {
++		printf("PASS: 0 returned as expected\n");
++		ksft_inc_pass_cnt();
++	}
++
++	return ksft_get_fail_cnt() ? KSFT_FAIL : KSFT_PASS;
++}
++
++int main(int argc, char **argv)
++{
++	const char kpath[] = "kcmp-test-file";
++	static char child_stack[64 * 1024];
++	struct child_args args;
+ 	struct epoll_event ev;
+ 	int pid1, pid2;
+ 	int pipefd[2];
+-	int fd1, fd2;
++	int fd1;
+ 	int epollfd;
+ 	int status;
+ 	int fddup;
+@@ -78,91 +168,24 @@
+ 	}
+ 	close(fddup);
+ 
+-	pid2 = fork();
++	args = (struct child_args) {
++		.parent_pid = pid1,
++		.parent_fd = fd1,
++		.pipe_write_fd = pipefd[1],
++		.epoll_fd = epollfd,
++	};
++	pid2 = clone(run_child, child_stack + sizeof(child_stack), SIGCHLD, &args);
+ 	if (pid2 < 0) {
+-		perror("fork failed");
++		perror("clone failed");
+ 		ksft_exit_fail();
+ 	}
+ 
+-	if (!pid2) {
+-		int pid2 = getpid();
+-		int ret;
+-
+-		ksft_print_header();
+-		ksft_set_plan(3);
+-
+-		fd2 = open(kpath, O_RDWR);
+-		if (fd2 < 0) {
+-			perror("Can't open file");
+-			ksft_exit_fail();
+-		}
+-
+-		/* An example of output and arguments */
+-		printf("pid1: %6d pid2: %6d FD: %2ld FILES: %2ld VM: %2ld "
+-		       "FS: %2ld SIGHAND: %2ld IO: %2ld SYSVSEM: %2ld "
+-		       "INV: %2ld\n",
+-		       pid1, pid2,
+-		       sys_kcmp(pid1, pid2, KCMP_FILE,		fd1, fd2),
+-		       sys_kcmp(pid1, pid2, KCMP_FILES,		0, 0),
+-		       sys_kcmp(pid1, pid2, KCMP_VM,		0, 0),
+-		       sys_kcmp(pid1, pid2, KCMP_FS,		0, 0),
+-		       sys_kcmp(pid1, pid2, KCMP_SIGHAND,	0, 0),
+-		       sys_kcmp(pid1, pid2, KCMP_IO,		0, 0),
+-		       sys_kcmp(pid1, pid2, KCMP_SYSVSEM,	0, 0),
+-
+-			/* This one should fail */
+-		       sys_kcmp(pid1, pid2, KCMP_TYPES + 1,	0, 0));
+-
+-		/* This one should return same fd */
+-		ret = sys_kcmp(pid1, pid2, KCMP_FILE, fd1, fd1);
+-		if (ret) {
+-			printf("FAIL: 0 expected but %d returned (%s)\n",
+-				ret, strerror(errno));
+-			ksft_inc_fail_cnt();
+-			ret = -1;
+-		} else {
+-			printf("PASS: 0 returned as expected\n");
+-			ksft_inc_pass_cnt();
+-		}
+-
+-		/* Compare with self */
+-		ret = sys_kcmp(pid1, pid1, KCMP_VM, 0, 0);
+-		if (ret) {
+-			printf("FAIL: 0 expected but %d returned (%s)\n",
+-				ret, strerror(errno));
+-			ksft_inc_fail_cnt();
+-			ret = -1;
+-		} else {
+-			printf("PASS: 0 returned as expected\n");
+-			ksft_inc_pass_cnt();
+-		}
+-
+-		/* Compare epoll target */
+-		epoll_slot = (struct kcmp_epoll_slot) {
+-			.efd	= epollfd,
+-			.tfd	= duped_num,
+-			.toff	= 0,
+-		};
+-		ret = sys_kcmp(pid1, pid1, KCMP_EPOLL_TFD, pipefd[1],
+-			       (unsigned long)(void *)&epoll_slot);
+-		if (ret) {
+-			printf("FAIL: 0 expected but %d returned (%s)\n",
+-				ret, strerror(errno));
+-			ksft_inc_fail_cnt();
+-			ret = -1;
+-		} else {
+-			printf("PASS: 0 returned as expected\n");
+-			ksft_inc_pass_cnt();
+-		}
+-
+-
+-		if (ret)
+-			ksft_exit_fail();
+-		else
+-			ksft_exit_pass();
++	if (waitpid(pid2, &status, 0) < 0) {
++		perror("waitpid failed");
++		ksft_exit_fail();
+ 	}
++	if (!WIFEXITED(status))
++		ksft_exit_fail();
+ 
+-	waitpid(pid2, &status, P_ALL);
+-
+-	return 0;
++	return WEXITSTATUS(status);
+ }

--- a/packages/kselftests/patches/mqueue-error-h-musl.patch
+++ b/packages/kselftests/patches/mqueue-error-h-musl.patch
@@ -1,0 +1,33 @@
+mq_open_tests uses two glibc extensions musl lacks: <error.h>/error() and the
+DEFFILEMODE (0666) macro from <sys/stat.h>. Provide a minimal error() shim from
+<stdarg.h> matching glibc behaviour at the one call site (format, append the
+errno string, exit if status is nonzero) and define DEFFILEMODE when absent. Not
+upstreamable as-is (upstream targets glibc); an upstream fix would gate both on
+__GLIBC__.
+
+--- a/tools/testing/selftests/mqueue/mq_open_tests.c
++++ b/tools/testing/selftests/mqueue/mq_open_tests.c
+@@ -31,7 +31,22 @@
+ #include <sys/resource.h>
+ #include <sys/stat.h>
+ #include <mqueue.h>
+-#include <error.h>
++#include <stdarg.h>
++
++#ifndef DEFFILEMODE
++#define DEFFILEMODE 0666
++#endif
++
++static void error(int status, int errnum, const char *fmt, ...)
++{
++	va_list ap;
++	va_start(ap, fmt);
++	vfprintf(stderr, fmt, ap);
++	va_end(ap);
++	fprintf(stderr, ": %s\n", strerror(errnum));
++	if (status)
++		exit(status);
++}
+ 
+ #include "../kselftest.h"
+ 

--- a/packages/kselftests/patches/openat2-drop-sanitizers.patch
+++ b/packages/kselftests/patches/openat2-drop-sanitizers.patch
@@ -1,0 +1,21 @@
+openat2's Makefile hardcodes -fsanitize=address,undefined into CFLAGS. Those
+runtimes are not available for static wasm32-musl (no shared libs, no asan
+runtime), so linking fails. Drop them; the tests themselves need no sanitizer to
+exercise the openat2 syscall. The target also passes helpers.h to the compiler
+as a second input while requesting one output, which Clang rejects; helpers.c
+already includes the header, so only make the source a direct target dependency.
+The sanitizer part is distro-only; the input fix is upstreamable.
+
+--- a/tools/testing/selftests/openat2/Makefile
++++ b/tools/testing/selftests/openat2/Makefile
+@@ -1,8 +1,8 @@
+ # SPDX-License-Identifier: GPL-2.0-or-later
+
+-CFLAGS += -Wall -O2 -g -fsanitize=address -fsanitize=undefined
++CFLAGS += -Wall -O2 -g
+ TEST_GEN_PROGS := openat2_test resolve_test rename_attack_test
+
+ include ../lib.mk
+ 
+-$(TEST_GEN_PROGS): helpers.c helpers.h
++$(TEST_GEN_PROGS): helpers.c

--- a/packages/kselftests/patches/pidfd-forkless-subset.patch
+++ b/packages/kselftests/patches/pidfd-forkless-subset.patch
@@ -1,0 +1,94 @@
+pidfd_test mixes useful libc clone(CLONE_PIDFD) coverage with fork(), pid and
+mount namespaces, and mmap. Replace its simple fork child with libc clone(),
+and omit only the namespace/PID-recycling and shared-mmap cases on wasm. This
+keeps both pidfd polling modes and the pidfd_send_signal cases executable while
+preserving the complete test on other architectures. This is specific to the
+wasm port's intentionally smaller process and memory surface.
+
+--- a/tools/testing/selftests/pidfd/pidfd_test.c
++++ b/tools/testing/selftests/pidfd/pidfd_test.c
+@@ -89,6 +89,13 @@ static int test_pidfd_send_signal_simple_success(void)
+ 	return 0;
+ }
+ 
++static char child_stack[64 * 1024];
++
++static int child_exit_success(void *unused)
++{
++	return EXIT_SUCCESS;
++}
++
+ static int test_pidfd_send_signal_exited_fail(void)
+ {
+ 	int pidfd, ret, saved_errno;
+@@ -103,14 +110,12 @@ static int test_pidfd_send_signal_exited_fail(void)
+ 		return 0;
+ 	}
+ 
+-	pid = fork();
++	pid = clone(child_exit_success, child_stack + sizeof(child_stack),
++		    SIGCHLD, NULL);
+ 	if (pid < 0)
+ 		ksft_exit_fail_msg("%s test: Failed to create new process\n",
+ 				   test_name);
+ 
+-	if (pid == 0)
+-		_exit(EXIT_SUCCESS);
+-
+ 	snprintf(buf, sizeof(buf), "/proc/%d", pid);
+ 
+ 	pidfd = open(buf, O_DIRECTORY | O_CLOEXEC);
+@@ -140,6 +145,7 @@ static int test_pidfd_send_signal_exited_fail(void)
+ 	return 0;
+ }
+ 
++#ifndef __wasm__
+ /*
+  * Maximum number of cycles we allow. This is equivalent to PID_MAX_DEFAULT.
+  * If users set a higher limit or we have cycled PIDFD_MAX_DEFAULT number of
+@@ -346,6 +352,7 @@ static int test_pidfd_send_signal_recycled_pid_fail(void)
+ 
+ 	return ret;
+ }
++#endif
+ 
+ static int test_pidfd_send_signal_syscall_support(void)
+ {
+@@ -477,6 +484,7 @@ static void test_pidfd_poll_exec(int use_waitpid)
+ 		ksft_test_result_pass("%s test: Passed\n", test_name);
+ }
+ 
++#ifndef __wasm__
+ static void *test_pidfd_poll_leader_exit_thread(void *priv)
+ {
+ 	ksft_print_msg("Child Thread: starting. pid %d tid %ld ; and sleeping\n",
+@@ -556,19 +564,28 @@ static void test_pidfd_poll_leader_exit(int use_waitpid)
+ 	else
+ 		ksft_test_result_pass("%s test: Passed\n", test_name);
+ }
++#endif
+ 
+ int main(int argc, char **argv)
+ {
+ 	ksft_print_header();
++#ifdef __wasm__
++	ksft_set_plan(5);
++#else
+ 	ksft_set_plan(8);
++#endif
+ 
+ 	test_pidfd_poll_exec(0);
+ 	test_pidfd_poll_exec(1);
++#ifndef __wasm__
+ 	test_pidfd_poll_leader_exit(0);
+ 	test_pidfd_poll_leader_exit(1);
++#endif
+ 	test_pidfd_send_signal_syscall_support();
+ 	test_pidfd_send_signal_simple_success();
+ 	test_pidfd_send_signal_exited_fail();
++#ifndef __wasm__
+ 	test_pidfd_send_signal_recycled_pid_fail();
++#endif
+ 
+ 	return ksft_exit_pass();
+ }

--- a/packages/kselftests/suites/futex-test.sh
+++ b/packages/kselftests/suites/futex-test.sh
@@ -1,0 +1,54 @@
+#!/bin/busybox sh
+
+# Runs a curated subset of the futex/functional kselftests as a port smoke test.
+# Each selected binary must pass. A skip is a regression: this suite only
+# contains tests whose platform prerequisites are deliberately supported.
+#
+# The subset is everything in futex/functional that needs nothing this platform
+# lacks and that clears the futex_waitv port bug. The binaries left out, and why:
+#   * futex_wait_wouldblock } exercise futex_waitv, which returns EFAULT here
+#   * futex_wait_timeout    } instead of the expected EWOULDBLOCK/ETIMEDOUT
+#                             (their non-waitv assertions pass); see the
+#                             package comment and the report for the bug.
+#   * futex_wait            - subtests use SysV shm (shmget) and a MAP_SHARED
+#                             file mmap; shm is not configured and mmap is
+#                             degraded here.
+#   * futex_waitv           - the futex_waitv syscall itself (see above).
+#   * futex_wait_uninitialized_heap  - probes an mmap'd heap page.
+#   * futex_wait_private_mapped_file - file-backed mmap plus a signal.
+#   * futex_requeue         - assumes a waiter thread blocks within 10ms of
+#                             pthread_create; web-worker thread spawn here can
+#                             exceed that, so the requeue finds no waiter.
+#   * futex_requeue_pi              } need a signal to interrupt a thread
+#   * futex_requeue_pi_signal_restart} blocked in a futex syscall; signal
+#                             delivery here is cooperative-only and cannot
+#                             preempt a blocked syscall.
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  echo "::vm-test::fail"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+# Runs one test binary and rejects kselftest's skip code along with failures.
+run() {
+  "$1"
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "$1 exited $rc"
+}
+
+# A child thread blocks in FUTEX_WAIT (private) for a full second, then the
+# parent's FUTEX_CMP_REQUEUE_PI must reject the mismatched source op with EINVAL
+# and a following FUTEX_WAKE releases the child. This exercises cross-thread
+# futex blocking, futex_wake, and the PI requeue validation path, and its
+# one-second settle tolerates this platform's web-worker thread-spawn latency.
+run futex_requeue_pi_mismatched_ops
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/packages/kselftests/suites/futex.nix
+++ b/packages/kselftests/suites/futex.nix
@@ -1,0 +1,9 @@
+# futex/functional: chosen first because its core syscall is wired here
+# (CONFIG_FUTEX=y, CONFIG_FUTEX_PI=y). Only the binary the check runs is built;
+# the rest lean on mmap, SysV shm, signal-interrupted syscalls, or the tabled
+# futex_waitv EFAULT bug (see futex-test.sh for the per-binary rationale).
+{
+  dir = "tools/testing/selftests/futex/functional";
+  binaries = [ "futex_requeue_pi_mismatched_ops" ];
+  run = ./futex-test.sh;
+}

--- a/packages/kselftests/suites/kcmp-test.sh
+++ b/packages/kselftests/suites/kcmp-test.sh
@@ -1,0 +1,24 @@
+#!/bin/busybox sh
+
+# kcmp_test compares fd, VM, and epoll state across a libc clone() child and its
+# parent. The source patch replaces the unavailable fork() call while preserving
+# process semantics and makes the parent propagate the child's kselftest result.
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  echo "::vm-test::fail"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+kcmp_test
+rc=$?
+[ "$rc" -eq 0 ] || fail "kcmp_test exited $rc"
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/packages/kselftests/suites/kcmp.nix
+++ b/packages/kselftests/suites/kcmp.nix
@@ -1,0 +1,8 @@
+# kcmp: the syscall and epoll dependency are enabled by syscalls.config. The
+# source patch replaces fork() with libc clone(), deliberately exercising the
+# wasm fn/fn_arg ABI with fork-like process semantics.
+{
+  dir = "tools/testing/selftests/kcmp";
+  binaries = [ "kcmp_test" ];
+  run = ./kcmp-test.sh;
+}

--- a/packages/kselftests/suites/mqueue-test.sh
+++ b/packages/kselftests/suites/mqueue-test.sh
@@ -1,0 +1,29 @@
+#!/bin/busybox sh
+
+# mq_open_tests opens POSIX message queues with a matrix of attribute structs and
+# checks the kernel's default/max clamping and EINVAL paths, reading the limits
+# from /proc/sys/fs/mqueue. No fork, thread, or mmap. It runs as root here, so
+# its root-only cases are exercised too.
+#
+# mq_perf_tests is held out: it is a benchmark that pins itself to CPUs, links
+# against -lpopt (absent from the sysroot), and measures latency rather than
+# asserting correctness.
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  echo "::vm-test::fail"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+mq_open_tests /test-queue
+rc=$?
+[ "$rc" -eq 0 ] || fail "mq_open_tests exited $rc"
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/packages/kselftests/suites/mqueue.nix
+++ b/packages/kselftests/suites/mqueue.nix
@@ -1,0 +1,12 @@
+# mqueue: POSIX message queues, enabled by CONFIG_POSIX_MQUEUE in
+# syscalls.config. Only mq_open_tests is built: it exercises mq_open attribute
+# validation with no fork, thread, or mmap. mq_perf_tests is held out (see
+# mqueue-test.sh). The Makefile's LDLIBS pulls in -lpopt, which the sysroot has
+# no library for; overriding LDLIBS drops it (mq_* and the rt stub are folded
+# into musl's libc, so -lrt alone links).
+{
+  dir = "tools/testing/selftests/mqueue";
+  binaries = [ "mq_open_tests" ];
+  makeFlags = [ "LDLIBS=-lrt" ];
+  run = ./mqueue-test.sh;
+}

--- a/packages/kselftests/suites/openat2-test.sh
+++ b/packages/kselftests/suites/openat2-test.sh
@@ -1,0 +1,31 @@
+#!/bin/busybox sh
+
+# openat2_test drives the openat2 syscall directly: it checks open_how size and
+# reserved-field validation, the RESOLVE_* flag combinations, and path
+# resolution against files it creates in the cwd. No process fork, no mmap.
+#
+# The suite's other binaries are held out:
+#   * resolve_test       - unshare(CLONE_NEWNS) + mount tmpfs; mount namespaces
+#                          are not configured and tmpfs needs MMU-backed shmem.
+#   * rename_attack_test - fork()s an attacker child, and fork() does not exist
+#                          on wasm (see kcmp.nix).
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  echo "::vm-test::fail"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+cd /tmp || fail "cd /tmp failed"
+openat2_test
+rc=$?
+[ "$rc" -eq 0 ] || fail "openat2_test exited $rc"
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/packages/kselftests/suites/openat2.nix
+++ b/packages/kselftests/suites/openat2.nix
@@ -1,0 +1,11 @@
+# openat2: the syscall is always compiled in (no config gate). Only openat2_test
+# is built — it validates the open_how struct and RESOLVE_* flag handling with
+# plain syscalls and needs no process or memory primitive. Its uapi header
+# (linux/openat2.h) reaches the compile via USERCFLAGS (its Makefile does not
+# wire KHDR_INCLUDES). The other two binaries are held out (see openat2-test.sh):
+# resolve_test needs mount namespaces + tmpfs, rename_attack_test needs fork().
+{
+  dir = "tools/testing/selftests/openat2";
+  binaries = [ "openat2_test" ];
+  run = ./openat2-test.sh;
+}

--- a/packages/kselftests/suites/pidfd-test.sh
+++ b/packages/kselftests/suites/pidfd-test.sh
@@ -1,0 +1,37 @@
+#!/bin/busybox sh
+
+# pidfd_open_test opens a pidfd for its own process and reads the pid back out of
+# /proc/self/fdinfo, plus the two rejection paths (invalid pid, invalid flag).
+# pidfd_test exercises CLONE_PIDFD through libc clone(), pidfd readiness through
+# epoll and waitpid, and pidfd_send_signal. The source patch holds out only its
+# namespace/PID-recycling and shared-mmap cases.
+#
+# The rest of the pidfd suite is held out:
+#   * pidfd_poll_test, pidfd_getfd_test - fork() an auxiliary process; fork() does
+#                                         not exist on wasm.
+#   * pidfd_wait                         - drives the raw clone3 stack ABI, which
+#                                         the wasm custom fn/fn_arg clone does not
+#                                         implement (skipped on principle).
+#   * pidfd_fdinfo_test, pidfd_setns_test - need PID/USER/NET/... namespaces,
+#                                           which are not configured.
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  echo "::vm-test::fail"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+for test in pidfd_open_test pidfd_test; do
+  "$test"
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "$test exited $rc"
+done
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/packages/kselftests/suites/pidfd.nix
+++ b/packages/kselftests/suites/pidfd.nix
@@ -1,0 +1,12 @@
+# pidfd: pidfd_open is always compiled in (no config gate). pidfd_open_test
+# validates its argument checks and /proc fdinfo. pidfd_test exercises
+# CLONE_PIDFD through libc clone(), pidfd polling, and pidfd_send_signal; its
+# namespace-only case is removed by the wasm compatibility patch.
+{
+  dir = "tools/testing/selftests/pidfd";
+  binaries = [
+    "pidfd_open_test"
+    "pidfd_test"
+  ];
+  run = ./pidfd-test.sh;
+}


### PR DESCRIPTION
<!-- jj-pr stack navigation -->
## Stack
- https://github.com/tombl/distro/pull/90
- https://github.com/tombl/distro/pull/91
- https://github.com/tombl/distro/pull/92
- https://github.com/tombl/distro/pull/88
- https://github.com/tombl/distro/pull/93
- https://github.com/tombl/distro/pull/94
- https://github.com/tombl/distro/pull/95
- https://github.com/tombl/distro/pull/96
- https://github.com/tombl/distro/pull/97
- https://github.com/tombl/distro/pull/98
- https://github.com/tombl/distro/pull/99
- https://github.com/tombl/distro/pull/100
- https://github.com/tombl/distro/pull/102
- https://github.com/tombl/distro/pull/101
- https://github.com/tombl/distro/pull/103 :point_left:
- https://github.com/tombl/distro/pull/104
- https://github.com/tombl/distro/pull/109
<!-- /jj-pr stack navigation -->