### PR TITLE
ci: build in one job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,60 +8,80 @@ on:
       - published
 
 jobs:
-  list:
-    runs-on: ubuntu-24.04
-    outputs:
-      matrix: ${{ steps.list.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: cachix/cachix-action@v17
-        with:
-          name: linuxwasm
-          authToken: "${{secrets.CACHIX_AUTH_TOKEN}}"
-      - name: List packages
-        id: list
-        run: |
-          eval "$(nix print-dev-env .#ci)"
-          matrix="$(nix-eval-jobs --flake .#checks.x86_64-linux --check-cache-status | jq -sc '
-            [
-              .[]
-              | select(.isCached | not).attr
-              | select(test("-shell$") | not)
-            ]
-            | if length > 0 then . else ["formatting"] end
-          ')"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   build:
-    needs: list
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        pkg: ${{ fromJson(needs.list.outputs.matrix) }}
-    name: Build ${{ matrix.pkg }}
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - uses: actions/checkout@v6
-      - uses: nixbuild/nix-quick-install-action@v34
+      - uses: nixbuild/nix-quick-install-action@v35
       - uses: cachix/cachix-action@v17
         with:
           name: linuxwasm
           authToken: "${{secrets.CACHIX_AUTH_TOKEN}}"
-      - name: Build
+      - name: Build checks
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          eval "$(nix print-dev-env .#ci)"
-          nix build '.#checks.x86_64-linux.${{ matrix.pkg }}^*' --print-build-logs
+          checks_file="$RUNNER_TEMP/checks.json"
+          nix eval --json '.#checks.x86_64-linux' --apply '
+            checks:
+            builtins.mapAttrs (
+              _: check:
+              {
+                drv = check.drvPath;
+                outputs = map (output: (builtins.getAttr output check).outPath) check.outputs;
+              }
+            ) checks
+          ' > "$checks_file"
 
-  packages:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: cachix/cachix-action@v17
-        with:
-          name: linuxwasm
-          authToken: "${{secrets.CACHIX_AUTH_TOKEN}}"
+          status() {
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+              --field state="$2" \
+              --field context="checks/$1" \
+              --field description="$3" \
+              --field target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+              >/dev/null
+          }
+
+          mapfile -t checks < <(jq --raw-output 'keys[]' "$checks_file")
+          installables=()
+          for check in "${checks[@]}"; do
+            status "$check" pending "Build in progress"
+            drv=$(jq --raw-output --arg check "$check" '.[$check].drv' "$checks_file")
+            installables+=("$drv^*")
+          done
+
+          set +e
+          nix build \
+            --max-jobs auto \
+            --keep-going \
+            --no-link \
+            --print-build-logs \
+            "${installables[@]}"
+          build_status=$?
+          set -e
+
+          for check in "${checks[@]}"; do
+            mapfile -t outputs < <(
+              jq --raw-output --arg check "$check" '.[$check].outputs[]' "$checks_file"
+            )
+            state=success
+            description="Build passed"
+            for output in "${outputs[@]}"; do
+              if ! nix path-info "$output" >/dev/null 2>&1; then
+                state=failure
+                description="Build failed"
+                break
+              fi
+            done
+            status "$check" "$state" "$description"
+          done
+
+          exit "$build_status"
       - name: Build npm packages
         run: |
           nix build .#linux --out-link result-linux --print-build-logs
@@ -76,23 +96,13 @@ jobs:
           if-no-files-found: error
 
   stage-npm:
-    name: Stage ${{ matrix.name }} on npm
-    needs:
-      - build
-      - packages
+    name: Stage packages on npm
+    needs: build
     if: github.event_name == 'release' && github.repository == 'tombl/distro'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "@tombl/linux"
-            tarball: linux.tgz
-          - name: "@tombl/linux-guest"
-            tarball: linux-guest.tgz
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -107,4 +117,6 @@ jobs:
       - name: Stage package
         env:
           NPM_TAG: ${{ github.event.release.prerelease && 'next' || 'latest' }}
-        run: npm stage publish "./npm-packages/${{ matrix.tarball }}" --access public --tag "$NPM_TAG"
+        run: |
+          npm stage publish ./npm-packages/linux.tgz --access public --tag "$NPM_TAG"
+          npm stage publish ./npm-packages/linux-guest.tgz --access public --tag "$NPM_TAG"

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,37 @@
             treefmt --ci
             touch $out
           '';
+
+          flake-inputs =
+            let
+              lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+              # The root node is this flake itself, and is the only node with no source.
+              nodes = builtins.attrValues (removeAttrs lock.nodes [ lock.root ]);
+
+              # Relative path inputs resolve against their parent, so they can't be fetched
+              # standalone — and they already live inside a source we root anyway.
+              isFetchable =
+                node: node.locked.type or null != "path" || builtins.substring 0 1 node.locked.path == "/";
+
+              # Inputs are content-addressed on narHash, so nodes sharing one are the same
+              # store path. Keying on it drops the duplicates that `follows` leaves behind.
+              unique = builtins.listToAttrs (
+                map (node: {
+                  name = node.locked.narHash;
+                  value = node;
+                }) (builtins.filter isFetchable nodes)
+              );
+
+              # The same expression nix uses in its own call-flake.nix.
+              fetchNode = node: (fetchTree (removeAttrs node.locked [ "dir" ])).outPath;
+
+              sources = map fetchNode (builtins.attrValues unique);
+            in
+            # Interpolating the store paths makes them inputSrcs of this derivation, so
+            # nix's reference scanner roots every input in the output's closure.
+            pkgs.writeText "flake-inputs" (builtins.concatStringsSep "\n" sources);
+
         }
       );
 
@@ -108,15 +139,6 @@
             env.sysroot = "${wasmpkgs.sysroot}";
           };
 
-          ci = pkgs.mkShellNoCC {
-            packages = [
-              pkgs.jq
-              pkgs.nix-eval-jobs
-              pkgs.nodejs
-              pkgs.pnpm_11
-              pkgs.wrangler
-            ];
-          };
         }
       );
 

--- a/packages/browser-tests/playwright.config.js
+++ b/packages/browser-tests/playwright.config.js
@@ -5,13 +5,11 @@ export default defineConfig({
   outputDir: process.env.PLAYWRIGHT_OUTPUT_DIR ?? "./test-results",
   timeout: 180_000,
   workers: 1,
-  use: {
-    baseURL: "http://127.0.0.1:4173",
-  },
   webServer: {
     command: "node server.js",
-    port: 4173,
-    reuseExistingServer: false,
+    wait: {
+      stdout: /Listening on (?<playwright_test_base_url>http:\/\/127\.0\.0\.1:\d+)/,
+    },
   },
   projects: [
     { name: "chromium", use: { browserName: "chromium" } },

--- a/packages/browser-tests/server.js
+++ b/packages/browser-tests/server.js
@@ -78,4 +78,6 @@ const server = createServer(async (request, response) => {
   createReadStream(path).pipe(response);
 });
 
-server.listen(4173, "127.0.0.1");
+server.listen(0, "127.0.0.1", () => {
+  console.log(`Listening on http://127.0.0.1:${server.address().port}`);
+});


### PR DESCRIPTION

Root flake inputs in a check so Cachix retains their source closures,
update CI to a Nix version with faster tarball-cache handling,
and run all checks plus package assembly in one job so each workflow
materializes the inputs only once, and builds intermediate dependencies
only once.