### PR TITLE
wasm: test remote process memory across browser workers

### DIFF
--- a/packages/basic-init/package.nix
+++ b/packages/basic-init/package.nix
@@ -172,6 +172,7 @@ in
       credentials = check "credentials";
       cwd = check "cwd";
       eventfd-unix = check "eventfd-unix";
+      exec-args = check "exec-args";
       futex = check "futex";
       initcpio = initcpioCheck;
       kernel-memory-growth = kernelMemoryGrowthCheck;

--- a/packages/basic-init/package.nix
+++ b/packages/basic-init/package.nix
@@ -48,6 +48,17 @@ let
     cpus = 2;
   };
 
+  remoteMemoryInitramfs = vm-test.mkInitramfs {
+    name = "basic-init-remote-memory";
+    init = "${buildInit "basic-init-remote-memory" "tests/remote-memory.c"}/bin/init";
+  };
+
+  remoteMemoryCheck = vm-test.vmTest {
+    name = "basic-init-remote-memory";
+    initramfs = remoteMemoryInitramfs;
+    cpus = 2;
+  };
+
   moduleDefinedMemory =
     pkgs.runCommand "module-defined-memory.wasm"
       {
@@ -139,7 +150,7 @@ let
 in
 (buildInit "basic-init" "init.c").overrideAttrs {
   passthru = {
-    inherit schedulerHandoffInitramfs;
+    inherit remoteMemoryInitramfs schedulerHandoffInitramfs;
     checks = {
       auxv = check "auxv";
       boot = check "boot";
@@ -171,6 +182,7 @@ in
       memory-abi = memoryAbiCheck;
       proc-self-mem = check "proc-self-mem";
       pty = check "pty";
+      remote-memory = remoteMemoryCheck;
       scheduler-handoff = schedulerHandoffCheck;
       setjmp = setjmpCheck;
       signal-syscall-return = signalSyscallReturnCheck "plain" "";

--- a/packages/basic-init/tests/exec-args.c
+++ b/packages/basic-init/tests/exec-args.c
@@ -1,0 +1,27 @@
+#include "test.h"
+
+#include <errno.h>
+#include <unistd.h>
+
+enum { argument_count = 45000 };
+
+static char *argv[argument_count + 1];
+
+int main(void)
+{
+	char *envp[] = { NULL };
+
+	for (int i = 0; i < argument_count; i++)
+		argv[i] = "x";
+
+	/*
+	 * The strings occupy only 90 KiB, but their pointer table pushes the
+	 * complete process blob beyond the wasm ABI's 256 KiB limit.
+	 */
+	errno = 0;
+	execve("/init", argv, envp);
+	if (errno != E2BIG)
+		test_perror("oversized argument blob did not fail with E2BIG");
+
+	test_pass();
+}

--- a/packages/basic-init/tests/remote-memory.c
+++ b/packages/basic-init/tests/remote-memory.c
@@ -1,0 +1,245 @@
+#define _GNU_SOURCE
+#include "test.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+enum {
+	reciprocal_iterations = 64,
+	stack_size = 64 * 1024,
+};
+
+#define TARGET_WAIT_NS (10LL * 1000 * 1000 * 1000)
+#define MAX_CANCEL_NS (8ULL * 1000 * 1000 * 1000)
+
+static int wait_word;
+static char probe[] = "remote-vm-parent";
+
+static uint64_t monotonic_ns(void)
+{
+	struct timespec now;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &now) == -1)
+		test_perror("clock_gettime");
+	return (uint64_t)now.tv_sec * 1000000000 + now.tv_nsec;
+}
+
+static void write_byte(int fd)
+{
+	char byte = 1;
+
+	if (write(fd, &byte, sizeof(byte)) != sizeof(byte))
+		test_perror("write synchronization byte");
+}
+
+static void read_byte(int fd)
+{
+	char byte;
+
+	if (read(fd, &byte, sizeof(byte)) != sizeof(byte))
+		test_perror("read synchronization byte");
+}
+
+static int open_mem(pid_t pid)
+{
+	char path[64];
+	int fd;
+
+	snprintf(path, sizeof(path), "/proc/%d/mem", pid);
+	fd = open(path, O_RDONLY);
+	if (fd == -1)
+		test_perror("open remote mem");
+	return fd;
+}
+
+struct cancel_args {
+	int ready;
+	int parked;
+	int release;
+};
+
+static int cancel_target(void *opaque)
+{
+	struct cancel_args *args = opaque;
+
+	write_byte(args->ready);
+
+	/*
+	 * Block in the browser worker without entering the kernel. No poll point
+	 * can service a remote request until this userspace wait expires.
+	 */
+	__builtin_wasm_memory_atomic_wait32(&wait_word, 0, TARGET_WAIT_NS);
+
+	write_byte(args->parked);
+	read_byte(args->release);
+	return 0;
+}
+
+static void test_cancellation(void)
+{
+	struct cancel_args args;
+	char *stack = malloc(stack_size);
+	char result[sizeof(probe)] = { 0 };
+	uint64_t before, elapsed;
+	int ready[2], parked[2], release[2];
+	int error, status, memfd;
+	ssize_t length;
+	pid_t pid;
+
+	if (!stack)
+		test_perror("malloc cancellation stack");
+	if (pipe(ready) == -1 || pipe(parked) == -1 || pipe(release) == -1)
+		test_perror("pipe cancellation synchronization");
+
+	args = (struct cancel_args) {
+		.ready = ready[1],
+		.parked = parked[1],
+		.release = release[0],
+	};
+	pid = clone(cancel_target, stack + stack_size, SIGCHLD, &args);
+	if (pid == -1)
+		test_perror("clone cancellation target");
+
+	memfd = open_mem(pid);
+	read_byte(ready[0]);
+	/*
+	 * Waking this process through the pipe can make the child reschedule at
+	 * syscall exit. Let it return to userspace and enter the atomic wait
+	 * before publishing the remote request.
+	 */
+	if (usleep(250000) == -1)
+		test_perror("settle cancellation target");
+
+	before = monotonic_ns();
+	length = pread(memfd, result, sizeof(result),
+		       (off_t)(uintptr_t)probe);
+	error = errno;
+	elapsed = monotonic_ns() - before;
+	if (length != -1 || error != EIO)
+		test_fail("busy target remote read did not cancel");
+	if (elapsed >= MAX_CANCEL_NS)
+		test_fail("busy target remote read exceeded its deadline");
+
+	read_byte(parked[0]);
+	length = pread(memfd, result, sizeof(result),
+		       (off_t)(uintptr_t)probe);
+	if (length != sizeof(result) ||
+	    memcmp(result, probe, sizeof(result)) != 0)
+		test_fail("parked target remote read returned wrong data");
+
+	write_byte(release[1]);
+	if (waitpid(pid, &status, 0) == -1)
+		test_perror("waitpid cancellation target");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		test_fail("cancellation target failed");
+	length = pread(memfd, result, sizeof(result),
+		       (off_t)(uintptr_t)probe);
+	if (length != 0)
+		test_fail("retained remote mem fd did not reach EOF after target exit");
+
+	close(memfd);
+	free(stack);
+}
+
+struct peer_args {
+	pid_t peer;
+	int send;
+	int receive;
+};
+
+/*
+ * Both peers publish and consume a synchronization byte before each access.
+ * With two logical CPUs this repeatedly drives the A -> B / B -> A overlap;
+ * each requester's wait loop must service the request addressed to itself.
+ */
+static int run_peer(pid_t peer, int send_fd, int receive_fd,
+		    const char *local, const char *expected)
+{
+	char result[sizeof(probe)];
+	int failed = 0;
+	int memfd;
+
+	memcpy(probe, local, sizeof(probe));
+	memfd = open_mem(peer);
+
+	for (int i = 0; i < reciprocal_iterations; i++) {
+		char byte = 1;
+		ssize_t length;
+
+		if (write(send_fd, &byte, sizeof(byte)) != sizeof(byte) ||
+		    read(receive_fd, &byte, sizeof(byte)) != sizeof(byte))
+			return 1;
+		length = pread(memfd, result, sizeof(result),
+			       (off_t)(uintptr_t)probe);
+		if (length != sizeof(result) ||
+		    memcmp(result, expected, sizeof(result)) != 0)
+			failed = 1;
+		/* Keep either peer from exiting while the other's read is live. */
+		if (write(send_fd, &byte, sizeof(byte)) != sizeof(byte) ||
+		    read(receive_fd, &byte, sizeof(byte)) != sizeof(byte))
+			return 1;
+	}
+
+	close(memfd);
+	return failed;
+}
+
+static int reciprocal_child(void *opaque)
+{
+	struct peer_args *args = opaque;
+
+	return run_peer(args->peer, args->send, args->receive,
+			"remote-vm-child!", "remote-vm-parent");
+}
+
+static void test_reciprocal_access(void)
+{
+	struct peer_args args;
+	char *stack = malloc(stack_size);
+	int parent_to_child[2], child_to_parent[2];
+	int parent_result;
+	int status;
+	pid_t pid;
+
+	if (!stack)
+		test_perror("malloc reciprocal stack");
+	if (pipe(parent_to_child) == -1 || pipe(child_to_parent) == -1)
+		test_perror("pipe reciprocal synchronization");
+
+	args = (struct peer_args) {
+		.peer = getpid(),
+		.send = child_to_parent[1],
+		.receive = parent_to_child[0],
+	};
+	pid = clone(reciprocal_child, stack + stack_size, SIGCHLD, &args);
+	if (pid == -1)
+		test_perror("clone reciprocal peer");
+
+	parent_result = run_peer(pid, parent_to_child[1], child_to_parent[0],
+				 "remote-vm-parent", "remote-vm-child!");
+	if (waitpid(pid, &status, 0) == -1)
+		test_perror("waitpid reciprocal peer");
+	if (parent_result || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		test_fail("reciprocal remote reads failed");
+
+	free(stack);
+}
+
+int main(void)
+{
+	if (mkdir("/proc", 0555) == -1 && errno != EEXIST)
+		test_perror("mkdir /proc");
+	if (mount("proc", "/proc", "proc", 0, NULL) == -1 && errno != EBUSY)
+		test_perror("mount proc");
+
+	test_cancellation();
+	test_reciprocal_access();
+	test_pass();
+}

--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -12,8 +12,8 @@ async function collectProcess(child) {
 
 // Boots a guest, runs the scenario, and always shuts the machine down.
 // Scenarios return plain JSON so specs assert on the result directly.
-async function withGuest(scenario) {
-  const guest = await spawnGuest();
+async function withGuest(scenario, options) {
+  const guest = await spawnGuest(options);
   try {
     return await scenario(guest);
   } finally {
@@ -39,9 +39,27 @@ globalThis.spawnStress = () =>
     return collectProcess(await guest.exec(["sh", "-c", script]));
   });
 
-globalThis.schedulerHandoffStress = async () => {
-  const response = await fetch("/scheduler-handoff.cpio");
-  if (!response.ok) throw new Error(`failed to load scheduler test: ${response.status}`);
+globalThis.remoteMemoryMetadata = () =>
+  withGuest(
+    async (guest) => {
+      const script = [
+        "MARKER=remote-vm-environ sleep 30 &",
+        "pid=$!",
+        "cmdline=$(tr '\\000' ' ' < /proc/$pid/cmdline)",
+        "environ=$(tr '\\000' '\\n' < /proc/$pid/environ)",
+        "auxv_size=$(wc -c < /proc/$pid/auxv)",
+        "kill $pid",
+        "wait $pid 2>/dev/null || true",
+        'printf \'cmdline=%s\\nenviron=%s\\nauxv=%s\\n\' "$cmdline" "$(printf \'%s\\n\' "$environ" | grep \'^MARKER=\')" "$auxv_size"',
+      ].join("\n");
+      return collectProcess(await guest.exec(["sh", "-c", script]));
+    },
+    { cpus: 1 },
+  );
+
+async function runInitramfs(path, cpus) {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(`failed to load ${path}: ${response.status}`);
   const initcpio = new Uint8Array(await response.arrayBuffer());
 
   let resolve;
@@ -72,7 +90,7 @@ globalThis.schedulerHandoffStress = async () => {
   });
 
   const machine = await spawnMachine({
-    cpus: 2,
+    cpus,
     devices: [consoleDevice(input, outputStream())],
     initcpio,
   });
@@ -88,4 +106,8 @@ globalThis.schedulerHandoffStress = async () => {
     machine.close();
     await machine.closed.catch(() => {});
   }
-};
+}
+
+globalThis.schedulerHandoffStress = () => runInitramfs("/scheduler-handoff.cpio", 2);
+
+globalThis.remoteMemoryProtocol = () => runInitramfs("/remote-vm.cpio", 2);

--- a/packages/browser-tests/package.nix
+++ b/packages/browser-tests/package.nix
@@ -25,6 +25,7 @@ let
         cp ${./index.html} $out/index.html
         cp ${./playwright.config.js} $out/playwright.config.js
         cp ${basic-init.schedulerHandoffInitramfs} $out/scheduler-handoff.cpio
+        cp ${basic-init.remoteMemoryInitramfs} $out/remote-vm.cpio
         cp ${./server.js} $out/server.js
         cp -r ${./tests} $out/tests
         cp -r ${pkgs.playwright-test}/lib/node_modules/@playwright/test $out/node_modules/@playwright/test

--- a/packages/browser-tests/server.js
+++ b/packages/browser-tests/server.js
@@ -58,6 +58,8 @@ const server = createServer(async (request, response) => {
         path = join(directory, relative.split("/").at(-1));
       } else if (relative === "scheduler-handoff.cpio") {
         path = await build("basic-init.schedulerHandoffInitramfs");
+      } else if (relative === "remote-vm.cpio") {
+        path = await build("basic-init.remoteMemoryInitramfs");
       }
     } catch (error) {
       console.error(`failed to build ${relative}:`, error.stderr ?? error);

--- a/packages/browser-tests/tests/remote-memory.spec.js
+++ b/packages/browser-tests/tests/remote-memory.spec.js
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test("reads live process metadata with one logical CPU", async ({ page }) => {
+  page.on("console", (message) => console.log(`[browser] ${message.text()}`));
+  page.on("pageerror", (error) => console.error(`[browser] ${error.stack ?? error}`));
+
+  await page.goto("/");
+  await expect
+    .poll(() => page.evaluate(() => typeof globalThis.remoteMemoryMetadata))
+    .toBe("function");
+  const result = await page.evaluate(() => globalThis.remoteMemoryMetadata());
+
+  expect(result.stderr).toBe("");
+  expect(result.status).toEqual({ code: 0, signal: null, success: true });
+  expect(result.stdout).toContain("cmdline=sleep 30 ");
+  expect(result.stdout).toContain("environ=MARKER=remote-vm-environ");
+  expect(result.stdout).toMatch(/auxv=[1-9][0-9]*/);
+});
+
+test("cancels and pumps reciprocal remote-memory requests", async ({ page }) => {
+  page.on("console", (message) => console.log(`[browser] ${message.text()}`));
+  page.on("pageerror", (error) => console.error(`[browser] ${error.stack ?? error}`));
+
+  await page.goto("/");
+  await expect
+    .poll(() => page.evaluate(() => typeof globalThis.remoteMemoryProtocol))
+    .toBe("function");
+  await page.evaluate(() => globalThis.remoteMemoryProtocol());
+});

--- a/packages/linux/package.nix
+++ b/packages/linux/package.nix
@@ -9,8 +9,8 @@
   src ? pkgs.fetchFromGitHub {
     owner = "tombl";
     repo = "linux";
-    rev = "3c5df86c8edd5f06ec8c7af7ad5e250e4521f5dc";
-    hash = "sha256-zPKiz9TWMkJ6kG2xYjVp27a/oDgub7rr2ygyM09gsp4=";
+    rev = "5c7d5c49f1db59b725ec9a15963d80686e736e78";
+    hash = "sha256-sEdF5lW09jOMok6gD8xmSO3086DCvldckAIWfEkxxv0=";
   },
 }:
 

--- a/packages/musl/package.nix
+++ b/packages/musl/package.nix
@@ -6,8 +6,8 @@
   src ? pkgs.fetchFromGitHub {
     owner = "tombl";
     repo = "musl";
-    rev = "9b922b721dc6ff59d97bff02ac3e3517cbc7e929";
-    hash = "sha256-hauHjeEgvsADegjQRWXHI54XjHCUTsYtboFVdWQzV8U=";
+    rev = "32b163fb0cb7c54500f0f79274bb0f7685d92b78";
+    hash = "sha256-6ZW7S83mrI+JGj1uMgdpC124x68kCN+e3l80IXtuP+E=";
   },
 }:
 

--- a/todo.md
+++ b/todo.md
@@ -42,3 +42,5 @@
 - Enable Python's `_multiprocessing` and `_posixshmem` after wasm musl and the
   kernel provide working POSIX named semaphores, with integration tests.
 - Document the subprocess `close_fds` fd-snapshot race.
+- Fix the browser CPU-handoff race where a stale typed-array view can throw a
+  `RangeError` after concurrent memory growth.


### PR DESCRIPTION

Add end-to-end regressions for foreign process memory and the complete exec argument image. Exercise parked-owner reads, pre-claim cancellation, reciprocal requests, /proc metadata, and a retained /proc/$pid/mem fd after target exit; verify an oversized replacement returns E2BIG without replacing the caller.

Run the remote protocol in Chromium, Firefox, and WebKit.

Depends on:
- https://github.com/tombl/linux/pull/36
- https://github.com/tombl/linux/pull/37
- https://github.com/tombl/linux/pull/39
- https://github.com/tombl/linux/pull/38
- https://github.com/tombl/musl/pull/10

<!-- jj-pr stack navigation -->
## Stack
- https://github.com/tombl/distro/pull/117 :point_left:
- https://github.com/tombl/distro/pull/118
<!-- /jj-pr stack navigation -->