### PR TITLE
browser-tests: cover remote-memory worker lifecycle

### DIFF
--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -57,6 +57,43 @@ globalThis.remoteMemoryMetadata = () =>
     { cpus: 1 },
   );
 
+let lifecycleGuest;
+
+globalThis.startRemoteMemoryLifecycle = async () => {
+  if (lifecycleGuest) throw new Error("remote-memory lifecycle guest is already running");
+  lifecycleGuest = await spawnGuest({ cpus: 1 });
+};
+
+globalThis.runRemoteMemoryLifecycleBatch = async (batch, iterations) => {
+  if (!lifecycleGuest) throw new Error("remote-memory lifecycle guest is not running");
+  const script = [
+    "i=0",
+    `while [ $i -lt ${iterations} ]; do`,
+    `  MARKER=remote-vm-lifecycle-${batch}-$i sleep 30 &`,
+    "  pid=$!",
+    "  cmdline=$(tr '\\000' ' ' < /proc/$pid/cmdline)",
+    "  environ=$(tr '\\000' '\\n' < /proc/$pid/environ | grep '^MARKER=')",
+    "  auxv_size=$(wc -c < /proc/$pid/auxv)",
+    "  kill $pid",
+    "  wait $pid 2>/dev/null || true",
+    '  [ "$cmdline" = "sleep 30 " ] || exit 10',
+    `  [ "$environ" = "MARKER=remote-vm-lifecycle-${batch}-$i" ] || exit 11`,
+    '  [ "$auxv_size" -gt 0 ] || exit 12',
+    "  i=$((i+1))",
+    "done",
+    "printf 'batch=%s processes=%s\\n' \"" + batch + '" "$i"',
+  ].join("\n");
+  return collectProcess(await lifecycleGuest.exec(["sh", "-c", script]));
+};
+
+globalThis.closeRemoteMemoryLifecycle = async () => {
+  if (!lifecycleGuest) return;
+  const guest = lifecycleGuest;
+  lifecycleGuest = undefined;
+  guest.machine.close();
+  await guest.machine.closed;
+};
+
 async function runInitramfs(path, cpus) {
   const response = await fetch(path);
   if (!response.ok) throw new Error(`failed to load ${path}: ${response.status}`);

--- a/packages/browser-tests/tests/remote-memory.spec.js
+++ b/packages/browser-tests/tests/remote-memory.spec.js
@@ -17,6 +17,88 @@ test("reads live process metadata with one logical CPU", async ({ page }) => {
   expect(result.stdout).toMatch(/auxv=[1-9][0-9]*/);
 });
 
+test("reclaims process workers after remote-memory churn", async ({ page }) => {
+  page.on("console", (message) => console.log(`[browser] ${message.text()}`));
+  page.on("pageerror", (error) => console.error(`[browser] ${error.stack ?? error}`));
+
+  const memorySample = async (stage) => {
+    const bytes = await page.evaluate(async () => {
+      const measure = performance.measureUserAgentSpecificMemory;
+      if (typeof measure !== "function") return null;
+      try {
+        return (await measure.call(performance)).bytes;
+      } catch {
+        return null;
+      }
+    });
+    console.log(JSON.stringify({ test: "remote-memory-lifecycle", stage, memoryBytes: bytes }));
+  };
+  const workerCount = () => page.workers().length;
+  const settledWorkerCount = async () => {
+    let previous;
+    let stable = 0;
+    await expect
+      .poll(
+        () => {
+          const current = workerCount();
+          stable = current === previous ? stable + 1 : 0;
+          previous = current;
+          return stable;
+        },
+        { intervals: [100, 200, 400, 800, 1_000] },
+      )
+      .toBeGreaterThanOrEqual(2);
+    return workerCount();
+  };
+  let workersCreated = 0;
+  let workersClosed = 0;
+  let peakWorkers = 0;
+  // The runtime asks the page-side machine controller to create every process
+  // worker, so these are top-level dedicated workers rather than workers nested
+  // beyond Playwright's page.workers() visibility.
+  page.on("worker", (worker) => {
+    workersCreated++;
+    peakWorkers = Math.max(peakWorkers, workerCount());
+    worker.on("close", () => workersClosed++);
+  });
+
+  await page.goto("/");
+  await expect
+    .poll(() => page.evaluate(() => typeof globalThis.startRemoteMemoryLifecycle))
+    .toBe("function");
+  const pageBaseline = workerCount();
+  await memorySample("before");
+
+  try {
+    await page.evaluate(() => globalThis.startRemoteMemoryLifecycle());
+    // The first guest command lazily creates persistent guest-agent lane
+    // workers. Warm those up before measuring process-worker reclamation.
+    const warmup = await page.evaluate(() => globalThis.runRemoteMemoryLifecycleBatch("warmup", 1));
+    expect(warmup.status).toEqual({ code: 0, signal: null, success: true });
+    const machineBaseline = await settledWorkerCount();
+    expect(machineBaseline).toBeGreaterThan(pageBaseline);
+
+    for (let batch = 0; batch < 3; batch++) {
+      const result = await page.evaluate(
+        ({ batch }) => globalThis.runRemoteMemoryLifecycleBatch(batch, 8),
+        { batch },
+      );
+      expect(result.stderr).toBe("");
+      expect(result.status).toEqual({ code: 0, signal: null, success: true });
+      expect(result.stdout).toBe(`batch=${batch} processes=8\n`);
+      await expect.poll(workerCount).toBe(machineBaseline);
+      await memorySample(`batch-${batch}`);
+    }
+    expect(peakWorkers).toBeGreaterThan(machineBaseline);
+  } finally {
+    await page.evaluate(() => globalThis.closeRemoteMemoryLifecycle());
+  }
+
+  await expect.poll(workerCount).toBe(pageBaseline);
+  await expect.poll(() => workersClosed).toBe(workersCreated);
+  await memorySample("after-close");
+});
+
 test("cancels and pumps reciprocal remote-memory requests", async ({ page }) => {
   page.on("console", (message) => console.log(`[browser] ${message.text()}`));
   page.on("pageerror", (error) => console.error(`[browser] ${error.stack ?? error}`));


### PR DESCRIPTION

Keep one guest machine open while three batches create, inspect, and reap processes, then verify Playwright-observed dedicated workers return to the machine baseline after every batch and disappear on machine close. Log optional user-agent-specific memory samples without asserting GC behavior.

Depends on https://github.com/tombl/linux/pull/38.

<!-- jj-pr stack navigation -->
## Stack
- https://github.com/tombl/distro/pull/117
- https://github.com/tombl/distro/pull/118 :point_left:
<!-- /jj-pr stack navigation -->