### PR TITLE
linux-guest: test user trap process isolation

### DIFF
--- a/packages/linux-guest/package.nix
+++ b/packages/linux-guest/package.nix
@@ -10,19 +10,23 @@
 }:
 
 let
-  network-test = stdenv.mkDerivation {
-    pname = "linux-guest-network-test";
-    version = "0.0.0";
-    dontUnpack = true;
-    buildPhase = ''
-      $CC -Wall -Wextra -Werror -Wno-error=unused-command-line-argument \
-        -Wl,--fatal-warnings -o network-test ${./tests/network-test.c}
-    '';
-    installPhase = ''
-      mkdir -p $out/bin
-      cp network-test $out/bin/
-    '';
-  };
+  test-program =
+    name: source:
+    stdenv.mkDerivation {
+      pname = "linux-guest-${name}";
+      version = "0.0.0";
+      dontUnpack = true;
+      buildPhase = ''
+        $CC -Wall -Wextra -Werror -Wno-error=unused-command-line-argument \
+          -Wl,--fatal-warnings -o ${name} ${source}
+      '';
+      installPhase = ''
+        mkdir -p $out/bin
+        cp ${name} $out/bin/
+      '';
+    };
+  network-test = test-program "network-test" ./tests/network-test.c;
+  user-trap = test-program "user-trap" ./tests/user-trap.c;
 
   lifecycle-initramfs = vm-test.mkInitramfs {
     name = "linux-guest-lifecycle";
@@ -37,6 +41,7 @@ let
     "lifecycle-initramfs.cpio" = lifecycle-initramfs;
     "rootfs.squashfs" = "${image}/rootfs.squashfs";
     "network-test" = "${network-test}/bin/network-test";
+    "user-trap" = "${user-trap}/bin/user-trap";
     "runner" = "${runner.package}/bin/wasm-linux-runner";
   };
 

--- a/packages/linux-guest/tests/assets.ts
+++ b/packages/linux-guest/tests/assets.ts
@@ -32,6 +32,9 @@ export const assets = {
 /** A static guest executable that exercises the guest-side network stack. */
 export const network_test = await readFile(join(directory, "network-test"));
 
+/** A static guest executable whose entrypoint executes Wasm `unreachable`. */
+export const user_trap = await readFile(join(directory, "user-trap"));
+
 export const lifecycle_assets = {
   initramfs: await readFile(join(directory, "lifecycle-initramfs.cpio")),
   initramfs_path: join(directory, "lifecycle-initramfs.cpio"),

--- a/packages/linux-guest/tests/fixture.ts
+++ b/packages/linux-guest/tests/fixture.ts
@@ -11,7 +11,7 @@ import { once } from "node:events";
 import { createConnection } from "node:net";
 import { Duplex } from "node:stream";
 import { test, type TestContext } from "node:test";
-import { assets, network_test } from "./assets.ts";
+import { assets, network_test, user_trap } from "./assets.ts";
 import { closed_input, console_output } from "./helpers.ts";
 
 export interface TestFixture {
@@ -51,6 +51,8 @@ export function guest_test(
       consoles.push(guest.machine.bootConsole.pipeTo(console_output()));
       await guest.fs.writeFile("/workspace/network-test", network_test);
       await guest.fs.chmod("/workspace/network-test", 0o755);
+      await guest.fs.writeFile("/workspace/user-trap", user_trap);
+      await guest.fs.chmod("/workspace/user-trap", 0o755);
       return guest;
     }
 

--- a/packages/linux-guest/tests/processes.test.ts
+++ b/packages/linux-guest/tests/processes.test.ts
@@ -73,6 +73,34 @@ guest_test("processes", async (t, fixture) => {
       });
     });
 
+    await t.test("isolates user module traps to the offending process", async () => {
+      const survivor = await guest.exec(["cat"]);
+      const survivor_output = collect(survivor.stdout);
+      const crashed = await guest.exec(["/workspace/user-trap"]);
+      assert.deepEqual(await crashed.status, {
+        success: false,
+        code: 0,
+        signal: 11,
+      });
+
+      const input = survivor.stdin.getWriter();
+      await input.write(new TextEncoder().encode("still running\n"));
+      await input.close();
+      assert.equal(new TextDecoder().decode(await survivor_output), "still running\n");
+      assert.deepEqual(await survivor.status, {
+        success: true,
+        code: 0,
+        signal: null,
+      });
+
+      const after = await guest.exec(["true"]);
+      assert.deepEqual(await after.status, {
+        success: true,
+        code: 0,
+        signal: null,
+      });
+    });
+
     await t.test("reports explicit exit statuses", async () => {
       const exited = await guest.exec(["sh", "-c", "exit 37"]);
       assert.deepEqual(await exited.status, {

--- a/packages/linux-guest/tests/user-trap.c
+++ b/packages/linux-guest/tests/user-trap.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+	__builtin_trap();
+}


### PR DESCRIPTION

Compile a tiny guest executable that traps with __builtin_trap(), then verify the linux-guest process fixture reports SIGSEGV without disrupting an already-running peer or preventing a later process launch.

This covers the user-memory worker isolation behavior related to https://github.com/tombl/linux/pull/38.

Agent-Session: amp:T-019fae9b-9504-7359-aa87-3ef3c48e9a53