### PR TITLE
linux-guest: add HTTP fetch networking adapters

### DIFF
--- a/packages/linux-guest/src/fetch.ts
+++ b/packages/linux-guest/src/fetch.ts
@@ -1,0 +1,174 @@
+// Fetch-backed outbound HTTP. Guests speak plaintext HTTP/1; the adapter
+// intentionally translates it to HTTPS Fetch. The supplied callback owns all
+// platform routing and policy.
+
+import {
+  ByteReader,
+  chunked_body,
+  declared_raw_body,
+  fixed_body,
+  parse_request_line,
+  serialize_head,
+  strip_hop_by_hop,
+} from "./http.ts";
+import type { NetworkOptions, TcpSession } from "./network.ts";
+
+const PLACEHOLDER_ADDRESS = "198.18.0.1";
+const encoder = new TextEncoder();
+const CONTINUE = encoder.encode("HTTP/1.1 100 Continue\r\n\r\n");
+const BAD_REQUEST = response_bytes("HTTP/1.1 400 Bad Request", "Bad Request\n");
+const EXPECTATION_FAILED = response_bytes(
+  "HTTP/1.1 417 Expectation Failed",
+  "Expectation Failed\n",
+);
+const NOT_IMPLEMENTED = response_bytes("HTTP/1.1 501 Not Implemented", "Not Implemented\n");
+const BAD_GATEWAY = response_bytes("HTTP/1.1 502 Bad Gateway", "Bad Gateway\n");
+
+function response_bytes(status: string, text: string) {
+  const body = encoder.encode(text);
+  const head = serialize_head(
+    status,
+    new Headers({
+      "content-type": "text/plain; charset=utf-8",
+      "content-length": String(body.byteLength),
+      connection: "close",
+    }),
+  );
+  const bytes = new Uint8Array(head.byteLength + body.byteLength);
+  bytes.set(head);
+  bytes.set(body, head.byteLength);
+  return bytes;
+}
+
+function request_url(host: string, target: string) {
+  if (/[/\\?#@\s\u0000-\u001f\u007f]/.test(host)) throw new Error("invalid HTTP Host");
+  const origin = new URL(`https://${host}/`);
+  if (origin.username || origin.password || origin.pathname !== "/" || origin.search || origin.hash)
+    throw new Error("invalid HTTP Host");
+  const url = new URL(target, origin);
+  if (url.origin !== origin.origin) throw new Error("invalid HTTP request target");
+  return url;
+}
+
+async function exchange(
+  session: TcpSession,
+  do_fetch: (request: Request) => Response | PromiseLike<Response>,
+) {
+  // This is a gateway request boundary: reject lone-LF syntax rather than
+  // allowing different HTTP parsers to disagree about message boundaries.
+  const reader = new ByteReader(session.readable, { strictCrlf: true });
+  const writer = session.writable.getWriter();
+  const abort = new AbortController();
+  const stop = () => abort.abort(session.signal.reason);
+  session.signal.addEventListener("abort", stop, { once: true });
+  if (session.signal.aborted) stop();
+  let final_output_started = false;
+  let response_reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  async function error_response(response: Uint8Array) {
+    final_output_started = true;
+    await writer.write(response);
+    await writer.close();
+  }
+  try {
+    try {
+      const head = await reader.head();
+      if (!head) return;
+      const { method, target } = parse_request_line(head.line);
+      if (method === "CONNECT" || head.headers.has("upgrade")) {
+        await error_response(NOT_IMPLEMENTED);
+        return;
+      }
+      const hosts = head.rawHeaders.filter(([name]) => name.toLowerCase() === "host");
+      if (hosts.length !== 1) throw new Error("HTTP request requires one Host header");
+      const framing = declared_raw_body(head);
+      const expectation = (head.headers.get("expect") ?? "").toLowerCase();
+      if (expectation !== "" && expectation !== "100-continue") {
+        await error_response(EXPECTATION_FAILED);
+        return;
+      }
+      if (expectation === "100-continue") {
+        await writer.write(CONTINUE);
+      }
+      const headers = new Headers(head.headers);
+      strip_hop_by_hop(headers, ["expect", "host", "content-length"]);
+      const body =
+        framing === undefined || framing === 0
+          ? undefined
+          : framing === "chunked"
+            ? chunked_body(reader)
+            : fixed_body(reader, framing);
+      if ((method === "GET" || method === "HEAD") && body) {
+        throw new Error(`${method} request cannot carry a Fetch body`);
+      }
+      const request = new Request(request_url(hosts[0]![1], target), {
+        method,
+        headers,
+        body,
+        // Required by Fetch implementations that support streaming uploads.
+        ...(body ? { duplex: "half" } : {}),
+        credentials: "omit",
+        redirect: "manual",
+        referrerPolicy: "no-referrer",
+        signal: abort.signal,
+      } as RequestInit);
+      let response: Response;
+      try {
+        response = await do_fetch(request);
+      } catch (error) {
+        if (abort.signal.aborted) throw error;
+        if (final_output_started) throw error;
+        await error_response(BAD_GATEWAY);
+        return;
+      }
+      if (response.status < 200 || response.status > 599) {
+        await error_response(BAD_GATEWAY);
+        return;
+      }
+      const out = new Headers(response.headers);
+      strip_hop_by_hop(out, ["content-encoding", "content-length"]);
+      out.set("connection", "close");
+      final_output_started = true;
+      await writer.write(serialize_head(`HTTP/1.1 ${response.status} ${response.statusText}`, out));
+      if (
+        response.body &&
+        method !== "HEAD" &&
+        response.status !== 204 &&
+        response.status !== 205 &&
+        response.status !== 304
+      ) {
+        response_reader = response.body.getReader();
+        for (;;) {
+          const { value, done } = await response_reader.read();
+          if (done) break;
+          await writer.write(value);
+        }
+      }
+      await writer.close();
+    } catch (error) {
+      if (final_output_started) throw error;
+      await error_response(BAD_REQUEST);
+    }
+  } finally {
+    session.signal.removeEventListener("abort", stop);
+    abort.abort("HTTP exchange complete");
+    await response_reader?.cancel("HTTP exchange complete").catch(() => {});
+    response_reader?.releaseLock();
+    await reader.cancel("HTTP exchange complete").catch(() => {});
+    reader.detach();
+    writer.releaseLock();
+  }
+}
+
+/**
+ * Creates networking that translates one plaintext guest HTTP/1 exchange per
+ * TCP connection into an HTTPS `Request`. The required callback controls the
+ * Fetch implementation and its platform policy; ambient `fetch` is never used.
+ */
+export function fetchNetwork(options: {
+  fetch(request: Request): Response | PromiseLike<Response>;
+}): NetworkOptions {
+  return {
+    resolveDns: () => Promise.resolve([PLACEHOLDER_ADDRESS]),
+    connectTcp: (session) => exchange(session, options.fetch),
+  };
+}

--- a/packages/linux-guest/src/guest-fetch.ts
+++ b/packages/linux-guest/src/guest-fetch.ts
@@ -1,0 +1,212 @@
+import {
+  ByteReader,
+  chunked_body,
+  chunked_encoder,
+  declared_body,
+  declared_raw_body,
+  eof_body,
+  fixed_body,
+  type HttpHead,
+  parse_status_line,
+  serialize_head,
+  strip_hop_by_hop,
+} from "./http.ts";
+import type { GuestNetwork, Network, TcpConnection } from "./network.ts";
+
+/**
+ * Turns a listener inside a guest into a fetch-like handler: each call opens
+ * one connection, streams the request in, and resolves to a streaming
+ * `Response`. One connect per call with a single attempt — a listener that is
+ * not up yet rejects, and retrying is the caller's concern.
+ */
+export function guestFetch(
+  network: GuestNetwork,
+  options: { port: number },
+): (request: Request) => Promise<Response>;
+export function guestFetch(
+  network: Network,
+  options: { hostname: string; port: number },
+): (request: Request) => Promise<Response>;
+export function guestFetch(
+  network: GuestNetwork | Network,
+  options: { hostname?: string; port: number },
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    request.signal.throwIfAborted();
+    const url = new URL(request.url);
+    const headers = new Headers(request.headers);
+    strip_hop_by_hop(headers, ["host"]);
+    // The real public host so absolute links the server generates stay correct.
+    headers.set("host", url.host);
+    headers.set("connection", "close");
+    const framing = declared_body(headers);
+    if (request.body && framing === undefined) {
+      headers.set("transfer-encoding", "chunked");
+    }
+
+    const connection = await (
+      network.connect as (options: {
+        hostname?: string;
+        port: number;
+        signal?: AbortSignal;
+      }) => Promise<TcpConnection>
+    )({ ...options, signal: request.signal });
+    let request_reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    let sent: Promise<void> | undefined;
+    try {
+      const writer = connection.writable.getWriter();
+      const line = `${request.method} ${url.pathname}${url.search} HTTP/1.1`;
+      const reader = new ByteReader(connection.readable);
+      let responded = false;
+      let send_error: unknown;
+      sent = send_request(
+        writer,
+        serialize_head(line, headers),
+        request.body,
+        typeof framing === "number" ? framing : undefined,
+        framing === undefined && request.body !== null,
+        (value) => {
+          request_reader = value;
+          if (responded && value)
+            void value.cancel("guest responded before upload completed").catch(() => {});
+        },
+      );
+      // Keep parsing concurrently. An already-parsed final response is
+      // authoritative even when the server closes without reading the upload.
+      void sent.catch((error) => {
+        send_error = error;
+        if (!responded) connection.close();
+      });
+      let head: Awaited<ReturnType<ByteReader["head"]>>;
+      try {
+        head = await reader.head();
+      } catch (error) {
+        throw send_error ?? error;
+      }
+      let parsed = head && parse_status_line(head.line);
+      while (head && parsed!.status < 200 && parsed!.status !== 101) {
+        try {
+          head = await reader.head();
+        } catch (error) {
+          throw send_error ?? error;
+        }
+        parsed = head && parse_status_line(head.line);
+      }
+      if (!head) throw new Error("guest closed the connection before responding");
+      const { status, text } = parsed!;
+      if (status === 101) throw new Error("HTTP protocol upgrades are not supported");
+
+      // A server may reject an upload without consuming it. Stop pulling new
+      // body bytes; any write already waiting on the TCP window is released
+      // when the response body closes the connection.
+      responded = true;
+      if (request_reader)
+        void request_reader.cancel("guest responded before upload completed").catch(() => {});
+
+      const exposed = new Headers(head.headers);
+      strip_hop_by_hop(exposed);
+      const body = response_body(request.method, status, head, reader, connection);
+      return new Response(body, {
+        status,
+        statusText: text,
+        headers: exposed,
+      });
+    } catch (error) {
+      // Ownership either transfers to the returned Response or ends here.
+      connection.close();
+      await request_reader?.cancel(error).catch(() => {});
+      await sent?.catch(() => {});
+      if (request.signal.aborted) throw request.signal.reason;
+      throw error;
+    }
+  };
+}
+
+function response_body(
+  method: string,
+  status: number,
+  head: HttpHead,
+  reader: ByteReader,
+  connection: TcpConnection,
+): ReadableStream<Uint8Array> | null {
+  if (method === "HEAD" || status === 204 || status === 205 || status === 304) {
+    connection.close();
+    return null;
+  }
+  const declared = declared_raw_body(head);
+  const body =
+    declared === "chunked"
+      ? chunked_body(reader)
+      : declared === undefined
+        ? eof_body(reader)
+        : fixed_body(reader, declared);
+  return closing(body, connection);
+}
+
+/** Wraps a body so the connection closes once it ends, errors, or is cancelled. */
+function closing(
+  body: ReadableStream<Uint8Array>,
+  connection: TcpConnection,
+): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
+  const close = () => connection.close();
+  return new ReadableStream({
+    async pull(controller) {
+      try {
+        const { value, done } = await reader.read();
+        if (done) {
+          close();
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (error) {
+        close();
+        throw error;
+      }
+    },
+    cancel(reason) {
+      close();
+      return reader.cancel(reason);
+    },
+  });
+}
+
+async function send_request(
+  writer: WritableStreamDefaultWriter<Uint8Array>,
+  head: Uint8Array,
+  body: ReadableStream<Uint8Array> | null,
+  declared: number | undefined,
+  chunked: boolean,
+  set_reader: (reader: ReadableStreamDefaultReader<Uint8Array> | undefined) => void,
+) {
+  await writer.write(head);
+  let written = 0;
+  if (body) {
+    const encoded = chunked ? body.pipeThrough(chunked_encoder()) : body;
+    const reader = encoded.getReader();
+    set_reader(reader);
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        written += value.byteLength;
+        if (declared !== undefined && written > declared) {
+          throw new Error("request body exceeds content-length");
+        }
+        await writer.write(value);
+      }
+    } catch (error) {
+      await reader.cancel(error).catch(() => {});
+      throw error;
+    } finally {
+      reader.releaseLock();
+      set_reader(undefined);
+    }
+  }
+  if (declared !== undefined && written !== declared) {
+    throw new Error("request body does not match content-length");
+  }
+  // Half-close: the guest sees FIN after the complete request.
+  await writer.close();
+}

--- a/packages/linux-guest/src/http.ts
+++ b/packages/linux-guest/src/http.ts
@@ -1,0 +1,331 @@
+// HTTP/1.1 message primitives shared by the fetch adapters. This is not a
+// general HTTP implementation: each adapter controls one end of its
+// conversation, so only the grammar a well-behaved peer produces is accepted.
+
+const MAX_HEAD_BYTES = 65536;
+const MAX_LINE_BYTES = 8192;
+const MAX_TRAILER_BYTES = 65536;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** A parsed HTTP message head: the start line and its header block. */
+export interface HttpHead {
+  line: string;
+  /** Header fields in wire order, before Fetch's Headers canonicalization. */
+  rawHeaders: readonly (readonly [string, string])[];
+  headers: Headers;
+}
+
+function parse_head(text: string, strict_crlf: boolean): HttpHead {
+  if (strict_crlf && /(^|[^\r])\n/.test(text)) {
+    throw new Error("HTTP requires CRLF line endings");
+  }
+  const lines = strict_crlf ? text.split("\r\n") : text.split(/\r?\n/);
+  const headers = new Headers();
+  const rawHeaders: [string, string][] = [];
+  for (const header of lines.slice(1)) {
+    if (header === "") continue;
+    const colon = header.indexOf(":");
+    if (colon <= 0 || /\s/.test(header.slice(0, colon))) {
+      throw new Error(`malformed HTTP header: ${header}`);
+    }
+    const name = header.slice(0, colon);
+    const value = header.slice(colon + 1).trim();
+    rawHeaders.push([name, value]);
+    headers.append(name, value);
+  }
+  return { line: lines[0]!, rawHeaders, headers };
+}
+
+/**
+ * A buffered reader over a byte stream: splits HTTP message heads from the
+ * body bytes that follow them.
+ */
+export class ByteReader {
+  #reader: ReadableStreamDefaultReader<Uint8Array>;
+  #buffer: Uint8Array = new Uint8Array(0);
+  #ended = false;
+  #strict_crlf: boolean;
+
+  constructor(stream: ReadableStream<Uint8Array>, options: { strictCrlf?: boolean } = {}) {
+    this.#reader = stream.getReader();
+    this.#strict_crlf = options.strictCrlf ?? false;
+  }
+
+  async #fill() {
+    while (!this.#ended) {
+      const { value, done } = await this.#reader.read();
+      if (done) {
+        this.#ended = true;
+        return false;
+      }
+      if (value.byteLength === 0) continue;
+      if (this.#buffer.byteLength === 0) {
+        this.#buffer = value;
+      } else {
+        const merged = new Uint8Array(this.#buffer.byteLength + value.byteLength);
+        merged.set(this.#buffer);
+        merged.set(value, this.#buffer.byteLength);
+        this.#buffer = merged;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  #consume(length: number) {
+    const bytes = this.#buffer.subarray(0, length);
+    this.#buffer = this.#buffer.subarray(length);
+    return bytes;
+  }
+
+  /**
+   * Reads a message head, ending at the first blank line. Resolves undefined
+   * on a clean end of stream before any byte.
+   */
+  async head(): Promise<HttpHead | undefined> {
+    let searched = 0;
+    for (;;) {
+      const bytes = this.#buffer;
+      for (let index = searched; index < bytes.byteLength - 1; index++) {
+        let end: number;
+        if (this.#strict_crlf) {
+          if (
+            bytes[index] !== 0x0d ||
+            bytes[index + 1] !== 0x0a ||
+            bytes[index + 2] !== 0x0d ||
+            bytes[index + 3] !== 0x0a
+          )
+            continue;
+          end = index + 4;
+        } else {
+          if (bytes[index] !== 0x0a) continue;
+          let next = index + 1;
+          if (bytes[next] === 0x0d) next++;
+          if (bytes[next] !== 0x0a) continue;
+          end = next + 1;
+        }
+        if (end > MAX_HEAD_BYTES) throw new Error("HTTP head too large");
+        const text = decoder.decode(this.#consume(end));
+        return parse_head(text, this.#strict_crlf);
+      }
+      searched = Math.max(0, bytes.byteLength - 3);
+      if (bytes.byteLength > MAX_HEAD_BYTES) throw new Error("HTTP head too large");
+      if (await this.#fill()) continue;
+      if (bytes.byteLength === 0) return undefined;
+      throw new Error("unexpected end of HTTP head");
+    }
+  }
+
+  /** Reads through the next LF, returning the line without its CR LF. */
+  async line(): Promise<string> {
+    for (;;) {
+      const index = this.#buffer.indexOf(0x0a);
+      if (index !== -1) {
+        if (index + 1 > MAX_LINE_BYTES) throw new Error("HTTP line too long");
+        const bytes = this.#consume(index + 1);
+        if (this.#strict_crlf && (index === 0 || bytes[index - 1] !== 0x0d)) {
+          throw new Error("HTTP requires CRLF line endings");
+        }
+        const end = index > 0 && bytes[index - 1] === 0x0d ? index - 1 : index;
+        return decoder.decode(bytes.subarray(0, end));
+      }
+      if (this.#buffer.byteLength > MAX_LINE_BYTES) throw new Error("HTTP line too long");
+      if (!(await this.#fill())) throw new Error("unexpected end of HTTP line");
+    }
+  }
+
+  /** Reads up to `limit` bytes, resolving undefined at the end of stream. */
+  async take(limit: number): Promise<Uint8Array | undefined> {
+    if (this.#buffer.byteLength === 0 && !(await this.#fill())) return undefined;
+    return this.#consume(Math.min(limit, this.#buffer.byteLength));
+  }
+
+  /** Cancels the underlying stream. */
+  cancel(reason?: unknown) {
+    return this.#reader.cancel(reason);
+  }
+
+  /** Releases transport ownership and returns bytes already read past the message. */
+  detach(): Uint8Array {
+    const unread = this.#buffer.slice();
+    this.#buffer = new Uint8Array(0);
+    this.#reader.releaseLock();
+    return unread;
+  }
+}
+
+/** Parses an origin-form HTTP/1.x request line, e.g. `GET /path HTTP/1.1`. */
+export function parse_request_line(line: string): { method: string; target: string } {
+  const match = /^([A-Z]+) (\/[^ ]*) HTTP\/1\.[01]$/.exec(line);
+  if (!match) throw new Error(`unsupported HTTP request line: ${line}`);
+  if (/[#\\\u0000-\u001f\u007f]/.test(match[2]!)) {
+    throw new Error(`unsupported HTTP request target: ${match[2]}`);
+  }
+  return { method: match[1]!, target: match[2]! };
+}
+
+/** Parses an HTTP/1.x status line, e.g. `HTTP/1.1 200 OK`. */
+export function parse_status_line(line: string): { status: number; text: string } {
+  const match = /^HTTP\/1\.[01] (\d{3})(?: (.*))?$/.exec(line);
+  if (!match) throw new Error(`malformed HTTP status line: ${line}`);
+  return { status: Number(match[1]), text: match[2] ?? "" };
+}
+
+/**
+ * The body framing a message head declares: a byte count, chunked transfer
+ * encoding, or nothing.
+ */
+export function declared_body(headers: Headers): number | "chunked" | undefined {
+  const encoding = headers.get("transfer-encoding");
+  const declared = headers.get("content-length");
+  if (encoding !== null) {
+    if (declared !== null)
+      throw new Error("HTTP message has both transfer-encoding and content-length");
+    if (encoding.toLowerCase() !== "chunked") {
+      throw new Error(`unsupported transfer encoding: ${encoding}`);
+    }
+    return "chunked";
+  }
+  if (declared === null) return undefined;
+  if (!/^[0-9]+$/.test(declared)) throw new Error(`invalid content length: ${declared}`);
+  const length = Number(declared);
+  if (!Number.isSafeInteger(length)) {
+    throw new Error(`invalid content length: ${declared}`);
+  }
+  return length;
+}
+
+/** Validates framing from ordered wire fields before Headers combines them. */
+export function declared_raw_body(head: HttpHead): number | "chunked" | undefined {
+  const lengths = head.rawHeaders.filter(([name]) => name.toLowerCase() === "content-length");
+  const encodings = head.rawHeaders.filter(([name]) => name.toLowerCase() === "transfer-encoding");
+  if (lengths.length > 1) throw new Error("HTTP message has duplicate content-length");
+  if (encodings.length > 1) throw new Error("HTTP message has duplicate transfer-encoding");
+  return declared_body(head.headers);
+}
+
+/** Streams exactly `length` body bytes, then ends. */
+export function fixed_body(reader: ByteReader, length: number): ReadableStream<Uint8Array> {
+  let remaining = length;
+  return new ReadableStream({
+    async pull(controller) {
+      if (remaining === 0) {
+        controller.close();
+        return;
+      }
+      const chunk = await reader.take(remaining);
+      if (!chunk) throw new Error("HTTP body ended early");
+      remaining -= chunk.byteLength;
+      controller.enqueue(chunk);
+      if (remaining === 0) controller.close();
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/** Decodes a chunked transfer coding, discarding any trailer fields. */
+export function chunked_body(reader: ByteReader): ReadableStream<Uint8Array> {
+  let remaining = 0;
+  let between_chunks = false;
+  return new ReadableStream({
+    async pull(controller) {
+      if (remaining === 0) {
+        if (between_chunks) {
+          if ((await reader.line()) !== "") throw new Error("malformed chunk boundary");
+          between_chunks = false;
+        }
+        const size = (await reader.line()).split(";")[0]!.trim();
+        if (!/^[0-9a-fA-F]+$/.test(size)) throw new Error(`malformed chunk size: ${size}`);
+        remaining = Number.parseInt(size, 16);
+        if (!Number.isSafeInteger(remaining)) throw new Error(`chunk size is too large: ${size}`);
+        if (remaining === 0) {
+          let trailer_bytes = 0;
+          for (;;) {
+            const trailer = await reader.line();
+            trailer_bytes += trailer.length + 2;
+            if (trailer_bytes > MAX_TRAILER_BYTES) throw new Error("HTTP trailers too large");
+            if (trailer === "") break;
+          }
+          controller.close();
+          return;
+        }
+      }
+      const chunk = await reader.take(remaining);
+      if (!chunk) throw new Error("HTTP body ended early");
+      remaining -= chunk.byteLength;
+      if (remaining === 0) between_chunks = true;
+      controller.enqueue(chunk);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/** Streams the remaining bytes until the connection ends. */
+export function eof_body(reader: ByteReader): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    async pull(controller) {
+      const chunk = await reader.take(Infinity);
+      if (chunk) controller.enqueue(chunk);
+      else controller.close();
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/** Applies the chunked transfer coding to a byte stream. */
+export function chunked_encoder(): TransformStream<Uint8Array, Uint8Array> {
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (chunk.byteLength === 0) return;
+      controller.enqueue(encoder.encode(`${chunk.byteLength.toString(16)}\r\n`));
+      controller.enqueue(chunk);
+      controller.enqueue(encoder.encode("\r\n"));
+    },
+    flush(controller) {
+      controller.enqueue(encoder.encode("0\r\n\r\n"));
+    },
+  });
+}
+
+const HOP_BY_HOP = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+/** Removes connection-scoped headers, including fields named by Connection. */
+export function strip_hop_by_hop(headers: Headers, additional: readonly string[] = []) {
+  const connection = headers.get("connection");
+  if (connection !== null) {
+    for (const name of connection.split(",")) {
+      const token = name.trim();
+      if (!/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(token)) {
+        throw new Error(`invalid Connection header: ${connection}`);
+      }
+      headers.delete(token);
+    }
+  }
+  for (const name of HOP_BY_HOP) headers.delete(name);
+  for (const name of additional) headers.delete(name);
+}
+
+/** Serializes a start line and headers into the bytes of a message head. */
+export function serialize_head(line: string, headers: Headers): Uint8Array {
+  let text = `${line}\r\n`;
+  for (const [name, value] of headers) text += `${name}: ${value}\r\n`;
+  return encoder.encode(`${text}\r\n`);
+}

--- a/packages/linux-guest/src/http.ts
+++ b/packages/linux-guest/src/http.ts
@@ -31,7 +31,13 @@ function parse_head(text: string, strict_crlf: boolean): HttpHead {
       throw new Error(`malformed HTTP header: ${header}`);
     }
     const name = header.slice(0, colon);
-    const value = header.slice(colon + 1).trim();
+    // RFC 9112 forbids CR inside field values, and control characters other
+    // than HTAB and SP have no place in them at all.
+    const raw_value = header.slice(colon + 1);
+    if (/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\r]/.test(raw_value)) {
+      throw new Error(`malformed HTTP header: ${header}`);
+    }
+    const value = raw_value.trim();
     rawHeaders.push([name, value]);
     headers.append(name, value);
   }
@@ -125,10 +131,16 @@ export class ByteReader {
       if (index !== -1) {
         if (index + 1 > MAX_LINE_BYTES) throw new Error("HTTP line too long");
         const bytes = this.#consume(index + 1);
-        if (this.#strict_crlf && (index === 0 || bytes[index - 1] !== 0x0d)) {
-          throw new Error("HTTP requires CRLF line endings");
-        }
         const end = index > 0 && bytes[index - 1] === 0x0d ? index - 1 : index;
+        if (this.#strict_crlf) {
+          if (index === 0 || bytes[index - 1] !== 0x0d) {
+            throw new Error("HTTP requires CRLF line endings");
+          }
+          // A CR may only be the line terminator, never inside the line.
+          for (let at = 0; at < end; at++) {
+            if (bytes[at] === 0x0d) throw new Error("HTTP requires CRLF line endings");
+          }
+        }
         return decoder.decode(bytes.subarray(0, end));
       }
       if (this.#buffer.byteLength > MAX_LINE_BYTES) throw new Error("HTTP line too long");
@@ -160,7 +172,9 @@ export class ByteReader {
 export function parse_request_line(line: string): { method: string; target: string } {
   const match = /^([A-Z]+) (\/[^ ]*) HTTP\/1\.[01]$/.exec(line);
   if (!match) throw new Error(`unsupported HTTP request line: ${line}`);
-  if (/[#\\\u0000-\u001f\u007f]/.test(match[2]!)) {
+  // Request targets are ASCII URIs; anything else (control characters,
+  // non-ASCII bytes, fragments) must be percent-encoded.
+  if (/[#\\\u0000-\u001f\u007f-\uffff]/.test(match[2]!)) {
     throw new Error(`unsupported HTTP request target: ${match[2]}`);
   }
   return { method: match[1]!, target: match[2]! };
@@ -227,6 +241,10 @@ export function fixed_body(reader: ByteReader, length: number): ReadableStream<U
   });
 }
 
+/** RFC 9112 chunk-size syntax: hex digits plus optional chunk extensions. */
+const CHUNK_SIZE_RE =
+  /^[0-9a-fA-F]+(?:;[!#$%&'*+.^_`|~0-9A-Za-z-]+(?:=(?:"[^"]*"|[!#$%&'*+.^_`|~0-9A-Za-z-]+))?)*$/;
+
 /** Decodes a chunked transfer coding, discarding any trailer fields. */
 export function chunked_body(reader: ByteReader): ReadableStream<Uint8Array> {
   let remaining = 0;
@@ -238,10 +256,12 @@ export function chunked_body(reader: ByteReader): ReadableStream<Uint8Array> {
           if ((await reader.line()) !== "") throw new Error("malformed chunk boundary");
           between_chunks = false;
         }
-        const size = (await reader.line()).split(";")[0]!.trim();
-        if (!/^[0-9a-fA-F]+$/.test(size)) throw new Error(`malformed chunk size: ${size}`);
-        remaining = Number.parseInt(size, 16);
-        if (!Number.isSafeInteger(remaining)) throw new Error(`chunk size is too large: ${size}`);
+        const size_line = await reader.line();
+        if (!CHUNK_SIZE_RE.test(size_line)) {
+          throw new Error(`malformed chunk size: ${size_line}`);
+        }
+        remaining = Number.parseInt(size_line, 16);
+        if (!Number.isSafeInteger(remaining)) throw new Error(`chunk size is too large: ${size_line}`);
         if (remaining === 0) {
           let trailer_bytes = 0;
           for (;;) {

--- a/packages/linux-guest/src/index.ts
+++ b/packages/linux-guest/src/index.ts
@@ -20,6 +20,8 @@ export {
   SeekMode,
   type WriteFileOptions,
 } from "./file.ts";
+export { fetchNetwork } from "./fetch.ts";
+export { guestFetch } from "./guest-fetch.ts";
 export { type Guest, type NetworkedGuest, spawnGuest, type SpawnGuestOptions } from "./machine.ts";
 export {
   createNetwork,
@@ -29,6 +31,7 @@ export {
   type NetworkOptions,
   type TcpConnection,
   type TcpConnectOptions,
+  type TcpSession,
   type UdpConnection,
   type UdpConnectOptions,
 } from "./network.ts";

--- a/packages/linux-guest/src/network.ts
+++ b/packages/linux-guest/src/network.ts
@@ -156,6 +156,8 @@ export interface TcpConnectOptions {
   hostname: string;
   port: number;
   transport?: "tcp";
+  /** Aborts the pending connection and any connection it establishes. */
+  signal?: AbortSignal;
 }
 
 export interface UdpConnectOptions {
@@ -165,10 +167,16 @@ export interface UdpConnectOptions {
   transport: "udp";
 }
 
-interface HostTcpConnection {
+/** One lazily established, supervised outbound guest TCP session. */
+export interface TcpSession {
+  /** The address selected by the guest connection. */
+  readonly target: { readonly hostname: string; readonly port: number };
+  /** Bytes received from the guest. The first read starts the TCP handshake. */
   readonly readable: ReadableStream<Uint8Array>;
+  /** Bytes sent to the guest. The first write or close starts the TCP handshake. */
   readonly writable: WritableStream<Uint8Array>;
-  close(): void;
+  /** Aborted when the guest or network tears down the flow. */
+  readonly signal: AbortSignal;
 }
 
 /**
@@ -177,17 +185,18 @@ interface HostTcpConnection {
  */
 export interface NetworkOptions {
   /**
-   * Opens a raw TCP connection on a guest's behalf whenever it connects
-   * outside the virtual subnet. `hostname` is a literal IPv4 address —
-   * `"127.0.0.1"` when the guest connects to the gateway — and the resolved
-   * value carries the connection as web streams: `{ readable, writable,
-   * close() }`.
+   * Handles one TCP session whenever a guest connects outside the virtual
+   * subnet. The callback starts at SYN receipt and lives for the whole
+   * connection. Its first stream read, write, or writable close starts the
+   * handshake; merely acquiring a reader or writer does not. Throwing before
+   * first I/O rejects the pending connection, while throwing afterwards resets
+   * it.
    *
    * In Node, implement it with `net.connect`. A browser has no raw TCP, so
    * there it bridges to whatever transport you control — a WebSocket proxy,
    * say.
    */
-  connectTcp: (options: { hostname: string; port: number }) => Promise<HostTcpConnection>;
+  connectTcp: (session: TcpSession) => void | PromiseLike<void>;
   /** Answers guest DNS A queries with the IPv4 addresses for `hostname`. */
   resolveDns: (hostname: string) => Promise<string[]>;
 }
@@ -385,8 +394,11 @@ interface TcpFlow {
   handshake?: PromiseWithResolvers<TcpConnection>;
   handshake_timeout?: ReturnType<typeof setTimeout>;
   readable?: ReadableStreamDefaultController<Uint8Array>;
-  outbound?: HostTcpConnection;
-  outbound_writer?: WritableStreamDefaultWriter<Uint8Array>;
+  activation?: Promise<void>;
+  activation_waiter?: PromiseWithResolvers<void>;
+  abort?: AbortController;
+  receive_demand?: boolean;
+  remove_external_abort?: () => void;
 }
 
 interface UdpFlow {
@@ -534,15 +546,15 @@ function dns_response(query: Uint8Array, addresses: readonly string[]) {
  * import { Duplex } from "node:stream";
  *
  * const network = createNetwork({
- *   async connectTcp({ hostname, port }) {
- *     const socket = createConnection({ host: hostname, port });
+ *   async connectTcp(session) {
+ *     const socket = createConnection({ host: session.target.hostname,
+ *       port: session.target.port, signal: session.signal });
  *     await once(socket, "connect");
  *     const streams = Duplex.toWeb(socket);
- *     return {
- *       readable: streams.readable as ReadableStream<Uint8Array>,
- *       writable: streams.writable as WritableStream<Uint8Array>,
- *       close: () => socket.destroy(),
- *     };
+ *     await Promise.all([
+ *       session.readable.pipeTo(streams.writable as WritableStream<Uint8Array>),
+ *       (streams.readable as ReadableStream<Uint8Array>).pipeTo(session.writable),
+ *     ]);
  *   },
  *   resolveDns: resolve4,
  * });
@@ -714,6 +726,7 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
 
   function tcp_receive_window(flow: TcpFlow) {
     if (!flow.readable) return TCP_RECEIVE_WINDOW;
+    if (flow.activation) return flow.receive_demand ? TCP_RECEIVE_WINDOW : 0;
     return Math.max(0, Math.min(TCP_RECEIVE_WINDOW, Math.floor(flow.readable.desiredSize ?? 0)));
   }
 
@@ -812,6 +825,10 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
       waiter.reject(error ?? new Error("TCP connection closed"));
     }
     flow.window_waiters.length = 0;
+    flow.remove_external_abort?.();
+    flow.activation_waiter?.reject(error ?? new Error("TCP connection closed"));
+    flow.activation_waiter = undefined;
+    flow.abort?.abort(error ?? new Error("TCP connection closed"));
     if (error !== undefined) {
       try {
         flow.readable?.error(error);
@@ -825,11 +842,6 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
       } catch {
         // The peer may already have closed the stream.
       }
-    }
-    try {
-      flow.outbound?.close();
-    } catch {
-      // Closing a connection is idempotent at this boundary.
     }
   }
 
@@ -847,19 +859,23 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
 
   function establish_tcp_flow(flow: TcpFlow) {
     flow.established = true;
+    flow.activation_waiter?.resolve();
+    flow.activation_waiter = undefined;
     if (flow.handshake_timeout !== undefined) {
       clearTimeout(flow.handshake_timeout);
       flow.handshake_timeout = undefined;
     }
   }
 
-  function host_tcp_connection(flow: TcpFlow): TcpConnection {
+  function host_tcp_connection(flow: TcpFlow, activate?: () => Promise<void>): TcpConnection {
     const readable = new ReadableStream<Uint8Array>(
       {
         start(controller) {
           flow.readable = controller;
         },
-        pull() {
+        async pull() {
+          flow.receive_demand = true;
+          await activate?.();
           update_tcp_window(flow);
         },
         cancel(reason) {
@@ -867,17 +883,19 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
         },
       },
       {
-        highWaterMark: TCP_RECEIVE_WINDOW,
+        highWaterMark: activate ? 0 : TCP_RECEIVE_WINDOW,
         size(chunk) {
           return chunk.byteLength;
         },
       },
     );
     const writable = new WritableStream<Uint8Array>({
-      write(chunk) {
+      async write(chunk) {
+        await activate?.();
         return send_tcp_data(flow, chunk);
       },
-      close() {
+      async close() {
+        await activate?.();
         return send_tcp_fin(flow);
       },
       abort(reason) {
@@ -895,27 +913,21 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
     };
   }
 
-  async function pump_outbound(flow: TcpFlow) {
-    const reader = flow.outbound!.readable.getReader();
-    try {
-      for (;;) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        await send_tcp_data(flow, value);
-      }
-      await send_tcp_fin(flow);
-    } catch (error) {
-      abort_tcp_flow(flow, error);
-    } finally {
-      reader.releaseLock();
-    }
+  function reject_outbound_tcp(flow: TcpFlow, error: unknown) {
+    const rst = tcp_segment(
+      flow.peer_ip,
+      flow.guest.ip,
+      flow.peer_port,
+      flow.guest_port,
+      0,
+      flow.receive_sequence,
+      TcpFlag.RST | TcpFlag.ACK,
+    );
+    void send_ip(flow.guest.macAddress, flow.peer_ip, flow.guest.ip, IpProtocol.TCP, rst);
+    close_tcp_flow(flow, error);
   }
 
-  async function start_outbound_tcp(
-    guest: Attachment,
-    ip: ParsedIpPacket,
-    segment: ParsedTcpSegment,
-  ) {
+  function start_outbound_tcp(guest: Attachment, ip: ParsedIpPacket, segment: ParsedTcpSegment) {
     const key = tcp_key(ip.source, segment.source_port, ip.destination, segment.destination_port);
     if (tcp_flows.has(key)) return;
     const initial = random_sequence();
@@ -938,36 +950,54 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
       peer_window: segment.window,
     };
     tcp_flows.set(key, flow);
+    const abort = new AbortController();
+    flow.abort = abort;
     expire_tcp_handshake(
       flow,
       `timed out connecting from ${guest.address}:${segment.source_port} to ${ipv4_string(ip.destination)}:${segment.destination_port}`,
     );
-    try {
-      flow.outbound = await connectTcp({
+    const activate = () => {
+      if (flow.activation) return flow.activation;
+      flow.activation = (async () => {
+        const waiter = Promise.withResolvers<void>();
+        // Teardown can win while SYN-ACK is still being emitted. Mark the
+        // waiter observed before that race; this task still awaits and reports
+        // its rejection below when emission succeeds.
+        void waiter.promise.catch(() => {});
+        flow.activation_waiter = waiter;
+        await send_tcp(flow, TcpFlag.SYN | TcpFlag.ACK);
+        flow.send_sequence = sequence_add(flow.send_sequence, 1);
+        await waiter.promise;
+      })();
+      return flow.activation;
+    };
+    const streams = host_tcp_connection(flow, activate);
+    const session: TcpSession = {
+      target: {
         hostname: ip.destination === GATEWAY_IP ? "127.0.0.1" : ipv4_string(ip.destination),
         port: segment.destination_port,
-      });
-      if (flow.closed) {
-        flow.outbound.close();
-        return;
-      }
-      flow.outbound_writer = flow.outbound.writable.getWriter();
-      await send_tcp(flow, TcpFlag.SYN | TcpFlag.ACK);
-      flow.send_sequence = sequence_add(flow.send_sequence, 1);
-    } catch (error) {
-      if (flow.closed) return;
-      const rst = tcp_segment(
-        ip.destination,
-        guest.ip,
-        segment.destination_port,
-        segment.source_port,
-        0,
-        sequence_add(segment.sequence, 1),
-        TcpFlag.RST | TcpFlag.ACK,
+      },
+      readable: streams.readable,
+      writable: streams.writable,
+      signal: abort.signal,
+    };
+    Promise.resolve()
+      .then(() => connectTcp(session))
+      .then(
+        () => {
+          if (flow.closed) return;
+          if (!flow.activation) {
+            reject_outbound_tcp(flow, new Error("TCP handler completed without using the session"));
+            return;
+          }
+          void send_tcp_fin(flow).catch((error) => abort_tcp_flow(flow, error));
+        },
+        (error) => {
+          if (flow.closed) return;
+          if (flow.activation) abort_tcp_flow(flow, error);
+          else reject_outbound_tcp(flow, error);
+        },
       );
-      await send_ip(guest.macAddress, ip.destination, guest.ip, IpProtocol.TCP, rst);
-      close_tcp_flow(flow, error);
-    }
   }
 
   async function process_tcp(flow: TcpFlow, segment: ParsedTcpSegment) {
@@ -997,7 +1027,6 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
       }
       if (segment.flags & TcpFlag.ACK && segment.acknowledgement === flow.send_sequence) {
         establish_tcp_flow(flow);
-        void pump_outbound(flow);
       }
       return;
     }
@@ -1009,25 +1038,20 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
       return;
     }
 
-    if (
-      !flow.outbound_writer &&
-      segment.payload.byteLength > 0 &&
-      segment.payload.byteLength > tcp_receive_window(flow)
-    ) {
+    if (segment.payload.byteLength > 0 && segment.payload.byteLength > tcp_receive_window(flow)) {
       await send_tcp(flow, TcpFlag.ACK);
       return;
     }
 
     if (segment.payload.byteLength > 0) {
-      if (flow.outbound_writer) await flow.outbound_writer.write(segment.payload.slice());
-      else flow.readable?.enqueue(segment.payload.slice());
+      flow.readable?.enqueue(segment.payload.slice());
+      flow.receive_demand = false;
       flow.receive_sequence = sequence_add(flow.receive_sequence, segment.payload.byteLength);
     }
     if (segment.flags & TcpFlag.FIN) {
       flow.receive_sequence = sequence_add(flow.receive_sequence, 1);
       flow.remote_ended = true;
-      if (flow.outbound_writer) await flow.outbound_writer.close();
-      else flow.readable?.close();
+      flow.readable?.close();
     }
     await send_tcp(flow, TcpFlag.ACK);
     if (flow.local_ended && flow.remote_ended && flow.ack_waiters.length === 0) {
@@ -1046,7 +1070,7 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
     const flow = tcp_flows.get(key);
     if (!flow) {
       if (segment.flags & TcpFlag.SYN && !(segment.flags & TcpFlag.ACK)) {
-        void start_outbound_tcp(guest, ip, segment).catch(() => {});
+        start_outbound_tcp(guest, ip, segment);
       }
       return;
     }
@@ -1236,6 +1260,7 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
   const gateway: EthernetPort = ethernet.addPort(receive_frame);
 
   function connect_tcp(options: TcpConnectOptions): Promise<TcpConnection> {
+    if (options.signal?.aborted) return Promise.reject(options.signal.reason);
     if (closed) return Promise.reject(new Error("network is closed"));
     if (!valid_port(options.port)) return Promise.reject(new TypeError("invalid TCP port"));
     let address: number;
@@ -1278,6 +1303,12 @@ export function createNetwork({ connectTcp, resolveDns }: NetworkOptions): Netwo
     void send_ip(guest.macAddress, GATEWAY_IP, guest.ip, IpProtocol.TCP, syn).catch((error) => {
       close_tcp_flow(flow, error);
     });
+    if (options.signal) {
+      const abort = () => abort_tcp_flow(flow, options.signal!.reason);
+      options.signal.addEventListener("abort", abort, { once: true });
+      flow.remove_external_abort = () => options.signal!.removeEventListener("abort", abort);
+      if (options.signal.aborted) abort();
+    }
     return handshake.promise;
   }
 

--- a/packages/linux-guest/tests/differential.test.ts
+++ b/packages/linux-guest/tests/differential.test.ts
@@ -1,0 +1,434 @@
+// Differential test: the fetch adapter's reading of guest HTTP/1.1 traffic
+// must agree with Node's own llhttp parser, which doubles as the oracle. One
+// seeded corpus of generated, edge-case, and mutated requests is run through
+// both; agreement rules:
+//
+//   - Node rejects a message -> the adapter must not forward it (it answers
+//     with its own 4xx/5xx instead). A proxy that accepts what the origin
+//     rejects is a request-smuggling hazard.
+//   - Node accepts a well-formed message -> the adapter must forward it, and
+//     the reconstructed request must equal Node's parse (after the documented
+//     hop-by-hop stripping).
+//   - Node accepts an out-of-contract message (lone LF, odd Host, ...) -> the
+//     adapter may reject it, but must still answer cleanly.
+//
+// The corpus is deterministic: failures reproduce from the seed and index.
+// FUZZ_SEED and FUZZ_SCALE override the defaults for deeper local runs.
+
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer, type IncomingMessage } from "node:http";
+import net from "node:net";
+import { type Duplex } from "node:stream";
+import { test } from "node:test";
+import { fetchNetwork } from "../src/fetch.ts";
+import type { NetworkOptions, TcpSession } from "../src/index.ts";
+import { build_request_corpus, type CorpusEntry } from "./fuzz.ts";
+import { collect } from "./helpers.ts";
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+const SEED = Number(process.env.FUZZ_SEED ?? "0x5eed");
+const SCALE = Number(process.env.FUZZ_SCALE ?? "1");
+const TIMEOUT_MS = 5000;
+
+// Fields the adapter removes before constructing the forwarded request; the
+// oracle parse is reduced the same way before comparison. Mirrors the list
+// in src/http.ts.
+const HOP_BY_HOP = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+const ALSO_STRIPPED = ["content-length", "expect", "host"];
+const ERROR_STATUSES = new Set([400, 417, 501, 502]);
+
+interface NodeParse {
+  ok: boolean;
+  timeout?: boolean;
+  method?: string;
+  url?: string;
+  headers?: string[];
+  body?: Uint8Array;
+}
+
+class OraclePending {
+  private done = false;
+  private body_complete = false;
+  private request_seen = false;
+  private resolve!: (result: NodeParse) => void;
+  private readonly timer: ReturnType<typeof setTimeout>;
+  readonly result: Promise<NodeParse>;
+
+  constructor() {
+    this.result = new Promise((resolve) => {
+      this.resolve = resolve;
+    });
+    this.timer = setTimeout(() => this.finish({ ok: false, timeout: true }), TIMEOUT_MS);
+  }
+
+  finish(result: NodeParse) {
+    if (this.done) return;
+    this.done = true;
+    clearTimeout(this.timer);
+    this.resolve(result);
+  }
+
+  /** A parse error after a complete request (e.g. data past Connection: close) must not override it. */
+  finishRejected() {
+    if (this.request_seen) {
+      // llhttp reports some failures only after delivering the request (e.g.
+      // data past `Connection: close`); the message itself parsed. Only a
+      // body that never completes is a rejection, so let its end event
+      // settle the question first.
+      setImmediate(() => {
+        if (!this.body_complete) this.finish({ ok: false });
+      });
+      return;
+    }
+    this.finish({ ok: false });
+  }
+
+  onRequest(request: IncomingMessage) {
+    this.request_seen = true;
+    const body: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => body.push(chunk));
+    request.on("end", () => {
+      this.body_complete = true;
+      this.finish({
+        ok: true,
+        method: request.method!,
+        url: request.url!,
+        headers: request.rawHeaders,
+        body: new Uint8Array(Buffer.concat(body)),
+      });
+    });
+  }
+}
+
+/**
+ * A node:http server that parses one request per connection. Entries route
+ * to connections in order; events route to entries by socket identity, so a
+ * straggling close from a finished connection can never finish the next one.
+ */
+class Oracle {
+  private readonly server = createServer();
+  private readonly queue: OraclePending[] = [];
+  private readonly bySocket = new Map<Duplex, OraclePending>();
+  private port = 0;
+
+  async listen() {
+    this.server.on("request", (request) => {
+      this.bySocket.get(request.socket)?.onRequest(request);
+    });
+    this.server.on("clientError", (_error, socket) => {
+      this.bySocket.get(socket)?.finishRejected();
+      socket.destroy();
+    });
+    this.server.on("connection", (socket) => {
+      assert.equal(this.queue.length, 1, "oracle connections must be sequential");
+      const entry = this.queue.shift()!;
+      this.bySocket.set(socket, entry);
+      socket.on("error", () => {});
+      socket.on("close", () => {
+        this.bySocket.get(socket)?.finish({ ok: false });
+        this.bySocket.delete(socket);
+      });
+    });
+    this.server.listen(0, "127.0.0.1");
+    await once(this.server, "listening");
+    this.port = (this.server.address() as { port: number }).port;
+  }
+
+  parse(bytes: Uint8Array): Promise<NodeParse> {
+    const entry = new OraclePending();
+    this.queue.push(entry);
+    const socket = net.connect(this.port, "127.0.0.1", () => {
+      socket.write(bytes);
+      socket.end();
+    });
+    socket.on("data", () => {});
+    socket.on("error", () => {});
+    return entry.result.then((result) => {
+      socket.destroy();
+      return result;
+    });
+  }
+
+  close() {
+    this.server.closeAllConnections();
+    this.server.close();
+  }
+}
+
+interface OursParse {
+  forwarded: boolean;
+  response: Uint8Array;
+  method?: string;
+  url?: URL;
+  headers?: [string, string][];
+  body?: Uint8Array;
+  credentials?: string;
+  redirect?: string;
+  referrerPolicy?: string;
+}
+
+/** Runs the adapter's exchange over in-process streams, capturing what it forwards. */
+async function ours_parse(bytes: Uint8Array): Promise<OursParse> {
+  const input = new TransformStream<Uint8Array, Uint8Array>();
+  const output = new TransformStream<Uint8Array, Uint8Array>();
+  const abort = new AbortController();
+  const session: TcpSession = {
+    target: { hostname: "198.18.0.1", port: 80 },
+    readable: input.readable,
+    writable: output.writable,
+    signal: abort.signal,
+  };
+  let captured: { request: Request; body: Uint8Array } | undefined;
+  const options: NetworkOptions = fetchNetwork({
+    fetch: async (request) => {
+      const body = request.body
+        ? new Uint8Array(await new Response(request.body).arrayBuffer())
+        : new Uint8Array();
+      captured = { request, body };
+      return new Response("ok");
+    },
+  });
+  const writer = input.writable.getWriter();
+  const written = writer.write(bytes).then(() => writer.close());
+  const handled = Promise.resolve().then(() => options.connectTcp(session));
+  const response = await with_timeout(
+    Promise.all([written, handled, collect(output.readable)]).then(([, , bytes]) => bytes),
+    `adapter stalled on input ${preview(bytes)}`,
+  );
+  if (captured) {
+    const statuses = [...decoder.decode(response).matchAll(/^HTTP\/1\.1 (\d{3})/gm)];
+    const status = statuses.at(-1)?.[1];
+    return {
+      forwarded: status === "200",
+      response,
+      method: captured.request.method,
+      url: new URL(captured.request.url),
+      headers: [...captured.request.headers] as [string, string][],
+      body: captured.body,
+      credentials: captured.request.credentials,
+      redirect: captured.request.redirect,
+      referrerPolicy: captured.request.referrerPolicy,
+    };
+  }
+  return { forwarded: false, response };
+}
+
+async function with_timeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const guard = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([promise, guard]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+function multimap(entries: Iterable<[string, string]>): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [name, value] of entries) {
+    const key = name.toLowerCase();
+    const normalized = value.trim();
+    map.set(key, map.has(key) ? `${map.get(key)}, ${normalized}` : normalized);
+  }
+  return map;
+}
+
+function strip_node_headers(raw: string[]): Map<string, string> {
+  const pairs: [string, string][] = [];
+  for (let index = 0; index + 1 < raw.length; index += 2) {
+    pairs.push([raw[index]!, raw[index + 1]!]);
+  }
+  const map = multimap(pairs);
+  const tokens = (map.get("connection") ?? "")
+    .split(",")
+    .map((token) => token.trim().toLowerCase());
+  for (const name of [...HOP_BY_HOP, ...tokens, ...ALSO_STRIPPED]) map.delete(name);
+  return map;
+}
+
+function node_host(headers: string[]): string {
+  for (let index = 0; index + 1 < headers.length; index += 2) {
+    if (headers[index]!.toLowerCase() === "host") return headers[index + 1]!;
+  }
+  return "";
+}
+
+function assert_request_fields(entry: CorpusEntry, node: NodeParse, ours: OursParse) {
+  const ours_url = ours.url!;
+  const node_url = new URL(node.url!, "https://placeholder");
+  assert.equal(ours.method, node.method, "method");
+  assert.equal(
+    ours_url.pathname + ours_url.search,
+    node_url.pathname + node_url.search,
+    "request target",
+  );
+  assert.equal(
+    ours_url.hostname,
+    node_host(node.headers!).replace(/:\d+$/, "").toLowerCase(),
+    "authority",
+  );
+  assert.deepEqual(multimap(ours.headers!), strip_node_headers(node.headers!), "headers");
+  assert.deepEqual(ours.body, node.body, "body");
+}
+
+function assert_clean_rejection(response: Uint8Array) {
+  const statuses = [...decoder.decode(response).matchAll(/^HTTP\/1\.1 (\d{3})/gm)];
+  const status = statuses.at(-1)?.[1];
+  assert.ok(
+    status !== undefined && ERROR_STATUSES.has(Number(status)),
+    `adapter must answer with its own error status, got ${preview(response, 128)}`,
+  );
+}
+
+function expects_continue(bytes: Uint8Array) {
+  return decoder.decode(bytes).toLowerCase().includes("expect: 100-continue");
+}
+
+function preview(bytes: Uint8Array, limit = 160): string {
+  const text = [...bytes.subarray(0, limit)]
+    .map((byte) =>
+      byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : `\\x${byte.toString(16).padStart(2, "0")}`,
+    )
+    .join("");
+  return JSON.stringify(`${text}${bytes.byteLength > limit ? "…" : ""}`);
+}
+
+function describe_input(entry: CorpusEntry, index: number) {
+  return `input #${index} (${entry.kind}, seed ${SEED}): ${preview(entry.bytes)}`;
+}
+
+test(`adapter agrees with node:http on the generated corpus (seed ${SEED}, scale ${SCALE})`, async (t) => {
+  const oracle = new Oracle();
+  await oracle.listen();
+  const corpus = build_request_corpus(SEED, SCALE);
+  const stats = {
+    forwarded: 0,
+    rejected: 0,
+    stricter: 0,
+    oracle_timeouts: 0,
+    interim: 0,
+    method_tokens: 0,
+  };
+  try {
+    for (let index = 0; index < corpus.length; index++) {
+      const entry = corpus[index]!;
+      if (entry.bytes.byteLength === 0) continue;
+      const node = await oracle.parse(entry.bytes);
+      if (node.timeout) {
+        stats.oracle_timeouts++;
+        continue;
+      }
+      const ours = await ours_parse(entry.bytes).catch((error) => {
+        assert.fail(`${describe_input(entry, index)}\noracle: ${node_summary(node)}\nadapter error: ${error}`);
+      });
+      try {
+        if (!node.ok) {
+          if (entry.kind === "valid") {
+            assert.fail("node:http rejected a well-formed request — corpus bug");
+          }
+          if (ours.forwarded) {
+            const explained = await method_only_divergence(oracle, entry, entry.bytes, ours);
+            if (!explained) {
+              assert.fail("adapter forwarded a request node:http rejected");
+            }
+            stats.method_tokens++;
+          } else {
+            stats.rejected++;
+            assert_clean_rejection(ours.response);
+          }
+        } else if (ours.forwarded) {
+          stats.forwarded++;
+          assert_request_fields(entry, node, ours);
+          assert.equal(ours.credentials, "omit");
+          assert.equal(ours.redirect, "manual");
+          assert.equal(ours.referrerPolicy, "no-referrer");
+          if (expects_continue(entry.bytes)) {
+            stats.interim++;
+            assert.match(
+              decoder.decode(ours.response),
+              /HTTP\/1\.1 100 Continue[\s\S]*HTTP\/1\.1 200/,
+            );
+          }
+        } else {
+          stats.stricter++;
+          if (entry.kind === "valid") {
+            assert.fail("adapter rejected a well-formed request node:http accepted");
+          }
+          assert_clean_rejection(ours.response);
+        }
+      } catch (error) {
+        if (error instanceof assert.AssertionError) {
+          assert.fail(
+            `${describe_input(entry, index)}\noracle: ${node_summary(node)}\nadapter: ${ours_summary(ours)}\n${error.message}`,
+          );
+        }
+        throw error;
+      }
+    }
+  } finally {
+    oracle.close();
+  }
+  t.diagnostic(
+    `corpus ${corpus.length} (valid 600, edge 500, mutant 600 per scale): ` +
+      `${stats.forwarded} forwarded and matched, ${stats.rejected} both rejected, ` +
+      `${stats.method_tokens} token-method divergences, ${stats.stricter} stricter than node, ` +
+      `${stats.interim} interim 100s, ${stats.oracle_timeouts} oracle timeouts`,
+  );
+  assert.ok(stats.forwarded >= corpus.length / 3, "suspiciously few requests forwarded");
+  assert.ok(stats.rejected > 0, "corpus must include rejected requests");
+  assert.ok(stats.oracle_timeouts === 0, "oracle must never stall");
+});
+
+/**
+ * Node's llhttp only recognizes the standard method table; RFC 9110 allows
+ * any token. The adapter forwards such methods and re-serializes the whole
+ * message, so to explain a node rejection the method must be the only
+ * difference: substituting GET must make node accept the input and parse it
+ * exactly as the adapter did.
+ */
+async function method_only_divergence(
+  oracle: Oracle,
+  entry: CorpusEntry,
+  bytes: Uint8Array,
+  ours: OursParse,
+): Promise<boolean> {
+  const line_end = bytes.indexOf(0x0a);
+  if (line_end === -1) return false;
+  const line = decoder.decode(bytes.subarray(0, line_end)).replace(/\r$/, "");
+  const match = /^([A-Za-z][A-Za-z0-9-]*) (.*)$/.exec(line);
+  if (!match || match[1] !== ours.method) return false;
+  const new_head = encoder.encode(`GET ${match[2]}\r`);
+  const substituted = new Uint8Array(new_head.byteLength + bytes.byteLength - line_end);
+  substituted.set(new_head);
+  substituted.set(bytes.subarray(line_end), new_head.byteLength);
+  const node = await oracle.parse(substituted);
+  if (!node.ok) return false;
+  assert_request_fields(entry, node, { ...ours, method: "GET" });
+  return true;
+}
+
+function node_summary(node: NodeParse) {
+  if (node.timeout) return "node: timed out";
+  return node.ok ? `node: ${node.method} ${node.url}` : "node: rejected";
+}
+
+function ours_summary(ours: OursParse) {
+  return ours.forwarded
+    ? `adapter: forwarded ${ours.method} ${ours.url}`
+    : `adapter: rejected (${preview(ours.response, 64)})`;
+}

--- a/packages/linux-guest/tests/fetch-network.test.ts
+++ b/packages/linux-guest/tests/fetch-network.test.ts
@@ -1,0 +1,381 @@
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { once } from "node:events";
+import { type AddressInfo } from "node:net";
+import { test } from "node:test";
+import {
+  consoleDevice,
+  createNetwork,
+  entropyDevice,
+  type NetworkedGuest,
+  type NetworkOptions,
+  spawnGuest,
+  type TcpSession,
+} from "../src/index.ts";
+import { fetchNetwork } from "../src/fetch.ts";
+import { ByteReader } from "../src/http.ts";
+import { assets } from "./assets.ts";
+import { closed_input, collect, console_output, pattern_bytes } from "./helpers.ts";
+
+const decoder = new TextDecoder();
+
+// The test server terminates plain HTTP, so map the https origin the adapter
+// builds onto its loopback port. fetch overwrites Host from the target URL, so
+// the reconstructed authority is preserved in a header the server can assert.
+function loopback_fetch(port: number): (request: Request) => Promise<Response> {
+  return (request) => {
+    const url = new URL(request.url);
+    const headers = new Headers(request.headers);
+    headers.set("x-origin-host", url.host);
+    const target = new URL(`http://127.0.0.1:${port}${url.pathname}${url.search}`);
+    return globalThis.fetch(target, {
+      method: request.method,
+      headers,
+      body: request.body,
+      duplex: "half",
+    } as RequestInit);
+  };
+}
+
+async function read_body(request: IncomingMessage) {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+async function with_guest(options: NetworkOptions, fn: (guest: NetworkedGuest) => Promise<void>) {
+  const network = createNetwork(options);
+  const guest = await spawnGuest({
+    cpus: 1,
+    network,
+    assets,
+    devices: [consoleDevice(closed_input(), console_output()), entropyDevice()],
+  });
+  const console_done = guest.machine.bootConsole.pipeTo(console_output());
+  try {
+    await fn(guest);
+  } finally {
+    network.close();
+    guest.machine.close();
+    await guest.machine.closed;
+    await console_done;
+  }
+}
+
+async function listen(server: Server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return (server.address() as AddressInfo).port;
+}
+
+test("resolves any name and reconstructs the request over fetch", async () => {
+  let seen: { method?: string; url?: string; host?: string } = {};
+  const server = createServer((request, response) => {
+    seen = {
+      method: request.method,
+      url: request.url,
+      host: request.headers["x-origin-host"] as string,
+    };
+    response.end("hello from the server");
+  });
+  const port = await listen(server);
+  try {
+    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
+      const wget = await guest.exec(["wget", "-q", "-O", "-", "http://example.test/greeting"]);
+      const [output, status] = await Promise.all([collect(wget.stdout), wget.status]);
+      assert.equal(decoder.decode(output), "hello from the server");
+      assert.deepEqual(status, { success: true, code: 0, signal: null });
+    });
+  } finally {
+    server.close();
+  }
+  assert.equal(seen.method, "GET");
+  assert.equal(seen.url, "/greeting");
+  assert.equal(seen.host, "example.test");
+});
+
+test("streams a large response through with its bytes intact", async () => {
+  const payload = pattern_bytes(1 << 20);
+  const server = createServer((_request, response) => response.end(Buffer.from(payload)));
+  const port = await listen(server);
+  try {
+    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
+      const wget = await guest.exec(["wget", "-q", "-O", "-", "http://example.test/blob"]);
+      const [output, status] = await Promise.all([collect(wget.stdout), wget.status]);
+      assert.deepEqual(output, payload);
+      assert.deepEqual(status, { success: true, code: 0, signal: null });
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("forwards a POST body framed by Content-Length", async () => {
+  let body: string | undefined;
+  const server = createServer(async (request, response) => {
+    body = (await read_body(request)).toString();
+    response.end("stored");
+  });
+  const port = await listen(server);
+  try {
+    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
+      const request =
+        "POST /submit HTTP/1.1\r\nHost: example.test\r\n" +
+        "Content-Length: 5\r\nConnection: close\r\n\r\nhello";
+      const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
+      const output = decoder.decode(await collect(nc.stdout));
+      assert.match(output, /^HTTP\/1\.1 200/);
+      assert.match(output, /stored$/);
+    });
+  } finally {
+    server.close();
+  }
+  assert.equal(body, "hello");
+});
+
+test("answers Expect: 100-continue with an interim response", async () => {
+  let body: string | undefined;
+  const server = createServer(async (request, response) => {
+    body = (await read_body(request)).toString();
+    response.end("accepted");
+  });
+  const port = await listen(server);
+  try {
+    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
+      const request =
+        "POST /expect HTTP/1.1\r\nHost: example.test\r\nExpect: 100-continue\r\n" +
+        "Content-Length: 4\r\nConnection: close\r\n\r\nbody";
+      const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
+      const output = decoder.decode(await collect(nc.stdout));
+      assert.match(output, /HTTP\/1\.1 100 Continue/);
+      assert.match(output, /HTTP\/1\.1 200/);
+      assert.match(output, /accepted$/);
+    });
+  } finally {
+    server.close();
+  }
+  assert.equal(body, "body");
+});
+
+test("decodes a chunked request body before forwarding", async () => {
+  let body: string | undefined;
+  const server = createServer(async (request, response) => {
+    body = (await read_body(request)).toString();
+    response.end("ok");
+  });
+  const port = await listen(server);
+  try {
+    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
+      const request =
+        "POST /chunked HTTP/1.1\r\nHost: example.test\r\nTransfer-Encoding: chunked\r\n" +
+        "Connection: close\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
+      const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
+      const output = decoder.decode(await collect(nc.stdout));
+      assert.match(output, /^HTTP\/1\.1 200/);
+    });
+  } finally {
+    server.close();
+  }
+  assert.equal(body, "hello world");
+});
+
+test("serializes a 502 when fetch rejects", async () => {
+  const network = fetchNetwork({
+    fetch: () => Promise.reject(new Error("upstream is unreachable")),
+  });
+  await with_guest(network, async (guest) => {
+    const request = "GET /down HTTP/1.1\r\nHost: example.test\r\nConnection: close\r\n\r\n";
+    const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
+    const output = decoder.decode(await collect(nc.stdout));
+    assert.match(output, /^HTTP\/1\.1 502 Bad Gateway/);
+    assert.match(output, /Bad Gateway\n$/);
+    assert.doesNotMatch(output, /upstream is unreachable/);
+  });
+});
+
+async function adapter_request(
+  network: ReturnType<typeof fetchNetwork>,
+  request: string,
+): Promise<string> {
+  const input = new TransformStream<Uint8Array, Uint8Array>();
+  const output = new TransformStream<Uint8Array, Uint8Array>();
+  const abort = new AbortController();
+  const session: TcpSession = {
+    target: { hostname: "198.18.0.1", port: 80 },
+    readable: input.readable,
+    writable: output.writable,
+    signal: abort.signal,
+  };
+  const handled = Promise.resolve().then(() => network.connectTcp(session));
+  const response = collect(output.readable);
+  const writer = input.writable.getWriter();
+  const written = (async () => {
+    await writer.write(new TextEncoder().encode(request));
+    await writer.close();
+  })();
+  const [, bytes] = await Promise.all([written, response, handled]);
+  return decoder.decode(bytes);
+}
+
+test("fetches without ambient browser authority and strips nominated headers", async () => {
+  let seen: Request | undefined;
+  const network = fetchNetwork({
+    fetch: (request) => {
+      seen = request;
+      assert.equal(request.headers.get("x-private"), null);
+      return Promise.resolve(
+        new Response("ok", {
+          headers: { connection: "x-response-private", "x-response-private": "secret" },
+        }),
+      );
+    },
+  });
+  const output = await adapter_request(
+    network,
+    "GET / HTTP/1.1\r\nHost: example.test\r\nConnection: x-private\r\nX-Private: secret\r\n\r\n",
+  );
+  assert.equal(seen?.url, "https://example.test/");
+  assert.equal(seen?.credentials, "omit");
+  assert.equal(seen?.redirect, "manual");
+  assert.equal(seen?.referrerPolicy, "no-referrer");
+  assert.doesNotMatch(output, /x-response-private/i);
+});
+
+test("accepts bodyless methods with Content-Length: 0", async () => {
+  const methods: string[] = [];
+  const network = fetchNetwork({
+    fetch: (request) => {
+      methods.push(request.method);
+      return Promise.resolve(new Response());
+    },
+  });
+  for (const method of ["GET", "HEAD"]) {
+    const output = await adapter_request(
+      network,
+      `${method} / HTTP/1.1\r\nHost: example.test\r\nContent-Length: 0\r\n\r\n`,
+    );
+    assert.match(output, /^HTTP\/1\.1 200/);
+  }
+  assert.deepEqual(methods, ["GET", "HEAD"]);
+});
+
+test("streams request bodies larger than the former adapter cap", async () => {
+  const length = 17 * 1024 * 1024;
+  let received = 0;
+  const network = fetchNetwork({
+    async fetch(request) {
+      for await (const chunk of request.body ?? []) received += chunk.byteLength;
+      return new Response("ok");
+    },
+  });
+  const input = new TransformStream<Uint8Array, Uint8Array>();
+  const output = new TransformStream<Uint8Array, Uint8Array>();
+  const session: TcpSession = {
+    target: { hostname: "198.18.0.1", port: 80 },
+    readable: input.readable,
+    writable: output.writable,
+    signal: new AbortController().signal,
+  };
+  const handled = Promise.resolve().then(() => network.connectTcp(session));
+  const response = collect(output.readable);
+  const writer = input.writable.getWriter();
+  await writer.write(
+    new TextEncoder().encode(
+      `POST /large HTTP/1.1\r\nHost: example.test\r\nContent-Length: ${length}\r\n\r\n`,
+    ),
+  );
+  const chunk = new Uint8Array(1024 * 1024);
+  for (let written = 0; written < length; written += chunk.byteLength) await writer.write(chunk);
+  await writer.close();
+  const [, bytes] = await Promise.all([handled, response]);
+  assert.equal(received, length);
+  assert.match(decoder.decode(bytes), /^HTTP\/1\.1 200/);
+});
+
+test("rejects Host values that can change URL structure", async () => {
+  let fetched = false;
+  const network = fetchNetwork({
+    fetch: () => {
+      fetched = true;
+      return Promise.resolve(new Response("unreachable"));
+    },
+  });
+  const output = await adapter_request(
+    network,
+    "GET / HTTP/1.1\r\nHost: user@example.test\r\n\r\n",
+  );
+  assert.match(output, /^HTTP\/1\.1 400 Bad Request/);
+  assert.equal(fetched, false);
+});
+
+test("rejects ambiguous, duplicate, and non-decimal content lengths", async () => {
+  let fetched = false;
+  const network = fetchNetwork({
+    fetch: () => {
+      fetched = true;
+      return new Response();
+    },
+  });
+  for (const framing of [
+    "Content-Length: 1e3\r\n",
+    "Content-Length: 5\r\nContent-Length: 5\r\n",
+    "Content-Length: 5\r\nTransfer-Encoding: chunked\r\n",
+  ]) {
+    const output = await adapter_request(
+      network,
+      `POST / HTTP/1.1\r\nHost: example.test\r\n${framing}\r\n`,
+    );
+    assert.match(output, /^HTTP\/1\.1 400 Bad Request/);
+  }
+  const lf_only = await adapter_request(network, "GET / HTTP/1.1\nHost: example.test\n\n");
+  assert.match(lf_only, /^HTTP\/1\.1 400 Bad Request/);
+  assert.equal(fetched, false);
+});
+
+test("backpressures an upstream fetch response when the guest stops reading", async () => {
+  let pulls = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls++;
+      controller.enqueue(new Uint8Array(1024));
+    },
+  });
+  const network = fetchNetwork({ fetch: () => Promise.resolve(new Response(body)) });
+  const input = new TransformStream<Uint8Array, Uint8Array>();
+  const output = new TransformStream<Uint8Array, Uint8Array>();
+  const abort = new AbortController();
+  const session: TcpSession = {
+    target: { hostname: "198.18.0.1", port: 80 },
+    readable: input.readable,
+    writable: output.writable,
+    signal: abort.signal,
+  };
+  const handled = Promise.resolve().then(() => network.connectTcp(session));
+  const response = new ByteReader(output.readable);
+  const response_head = response.head();
+  const writer = input.writable.getWriter();
+  await writer.write(new TextEncoder().encode("GET / HTTP/1.1\r\nHost: example.test\r\n\r\n"));
+  const request_closed = writer.close();
+  assert.equal((await response_head)?.line, "HTTP/1.1 200 ");
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  assert.ok(pulls <= 2, `upstream body was pulled ${pulls} times without downstream reads`);
+  await response.cancel("test complete");
+  await assert.rejects(handled);
+  await request_closed.catch(() => {});
+});
+
+test("rejecting before first I/O refuses the pending guest connection", async () => {
+  let aborted = false;
+  const options: NetworkOptions = {
+    resolveDns: () => Promise.resolve(["198.18.0.1"]),
+    connectTcp(session) {
+      session.signal.addEventListener("abort", () => (aborted = true), { once: true });
+      throw new Error("refused before activation");
+    },
+  };
+  await with_guest(options, async (guest) => {
+    const nc = await guest.exec(["nc", "-w", "1", "198.18.0.1", "80"]);
+    assert.equal((await nc.status).success, false);
+  });
+  assert.equal(aborted, true);
+});

--- a/packages/linux-guest/tests/fetch-network.test.ts
+++ b/packages/linux-guest/tests/fetch-network.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createServer, type IncomingMessage, type Server } from "node:http";
+import { createServer, type Server } from "node:http";
 import { once } from "node:events";
 import { type AddressInfo } from "node:net";
 import { test } from "node:test";
@@ -35,12 +35,6 @@ function loopback_fetch(port: number): (request: Request) => Promise<Response> {
       duplex: "half",
     } as RequestInit);
   };
-}
-
-async function read_body(request: IncomingMessage) {
-  const chunks: Buffer[] = [];
-  for await (const chunk of request) chunks.push(chunk);
-  return Buffer.concat(chunks);
 }
 
 async function with_guest(options: NetworkOptions, fn: (guest: NetworkedGuest) => Promise<void>) {
@@ -110,75 +104,6 @@ test("streams a large response through with its bytes intact", async () => {
   }
 });
 
-test("forwards a POST body framed by Content-Length", async () => {
-  let body: string | undefined;
-  const server = createServer(async (request, response) => {
-    body = (await read_body(request)).toString();
-    response.end("stored");
-  });
-  const port = await listen(server);
-  try {
-    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
-      const request =
-        "POST /submit HTTP/1.1\r\nHost: example.test\r\n" +
-        "Content-Length: 5\r\nConnection: close\r\n\r\nhello";
-      const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
-      const output = decoder.decode(await collect(nc.stdout));
-      assert.match(output, /^HTTP\/1\.1 200/);
-      assert.match(output, /stored$/);
-    });
-  } finally {
-    server.close();
-  }
-  assert.equal(body, "hello");
-});
-
-test("answers Expect: 100-continue with an interim response", async () => {
-  let body: string | undefined;
-  const server = createServer(async (request, response) => {
-    body = (await read_body(request)).toString();
-    response.end("accepted");
-  });
-  const port = await listen(server);
-  try {
-    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
-      const request =
-        "POST /expect HTTP/1.1\r\nHost: example.test\r\nExpect: 100-continue\r\n" +
-        "Content-Length: 4\r\nConnection: close\r\n\r\nbody";
-      const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
-      const output = decoder.decode(await collect(nc.stdout));
-      assert.match(output, /HTTP\/1\.1 100 Continue/);
-      assert.match(output, /HTTP\/1\.1 200/);
-      assert.match(output, /accepted$/);
-    });
-  } finally {
-    server.close();
-  }
-  assert.equal(body, "body");
-});
-
-test("decodes a chunked request body before forwarding", async () => {
-  let body: string | undefined;
-  const server = createServer(async (request, response) => {
-    body = (await read_body(request)).toString();
-    response.end("ok");
-  });
-  const port = await listen(server);
-  try {
-    await with_guest(fetchNetwork({ fetch: loopback_fetch(port) }), async (guest) => {
-      const request =
-        "POST /chunked HTTP/1.1\r\nHost: example.test\r\nTransfer-Encoding: chunked\r\n" +
-        "Connection: close\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
-      const nc = await guest.exec(["sh", "-c", `printf '${request}' | nc 198.18.0.1 80`]);
-      const output = decoder.decode(await collect(nc.stdout));
-      assert.match(output, /^HTTP\/1\.1 200/);
-    });
-  } finally {
-    server.close();
-  }
-  assert.equal(body, "hello world");
-});
-
 test("serializes a 502 when fetch rejects", async () => {
   const network = fetchNetwork({
     fetch: () => Promise.reject(new Error("upstream is unreachable")),
@@ -217,48 +142,6 @@ async function adapter_request(
   return decoder.decode(bytes);
 }
 
-test("fetches without ambient browser authority and strips nominated headers", async () => {
-  let seen: Request | undefined;
-  const network = fetchNetwork({
-    fetch: (request) => {
-      seen = request;
-      assert.equal(request.headers.get("x-private"), null);
-      return Promise.resolve(
-        new Response("ok", {
-          headers: { connection: "x-response-private", "x-response-private": "secret" },
-        }),
-      );
-    },
-  });
-  const output = await adapter_request(
-    network,
-    "GET / HTTP/1.1\r\nHost: example.test\r\nConnection: x-private\r\nX-Private: secret\r\n\r\n",
-  );
-  assert.equal(seen?.url, "https://example.test/");
-  assert.equal(seen?.credentials, "omit");
-  assert.equal(seen?.redirect, "manual");
-  assert.equal(seen?.referrerPolicy, "no-referrer");
-  assert.doesNotMatch(output, /x-response-private/i);
-});
-
-test("accepts bodyless methods with Content-Length: 0", async () => {
-  const methods: string[] = [];
-  const network = fetchNetwork({
-    fetch: (request) => {
-      methods.push(request.method);
-      return Promise.resolve(new Response());
-    },
-  });
-  for (const method of ["GET", "HEAD"]) {
-    const output = await adapter_request(
-      network,
-      `${method} / HTTP/1.1\r\nHost: example.test\r\nContent-Length: 0\r\n\r\n`,
-    );
-    assert.match(output, /^HTTP\/1\.1 200/);
-  }
-  assert.deepEqual(methods, ["GET", "HEAD"]);
-});
-
 test("streams request bodies larger than the former adapter cap", async () => {
   const length = 17 * 1024 * 1024;
   let received = 0;
@@ -290,46 +173,6 @@ test("streams request bodies larger than the former adapter cap", async () => {
   const [, bytes] = await Promise.all([handled, response]);
   assert.equal(received, length);
   assert.match(decoder.decode(bytes), /^HTTP\/1\.1 200/);
-});
-
-test("rejects Host values that can change URL structure", async () => {
-  let fetched = false;
-  const network = fetchNetwork({
-    fetch: () => {
-      fetched = true;
-      return Promise.resolve(new Response("unreachable"));
-    },
-  });
-  const output = await adapter_request(
-    network,
-    "GET / HTTP/1.1\r\nHost: user@example.test\r\n\r\n",
-  );
-  assert.match(output, /^HTTP\/1\.1 400 Bad Request/);
-  assert.equal(fetched, false);
-});
-
-test("rejects ambiguous, duplicate, and non-decimal content lengths", async () => {
-  let fetched = false;
-  const network = fetchNetwork({
-    fetch: () => {
-      fetched = true;
-      return new Response();
-    },
-  });
-  for (const framing of [
-    "Content-Length: 1e3\r\n",
-    "Content-Length: 5\r\nContent-Length: 5\r\n",
-    "Content-Length: 5\r\nTransfer-Encoding: chunked\r\n",
-  ]) {
-    const output = await adapter_request(
-      network,
-      `POST / HTTP/1.1\r\nHost: example.test\r\n${framing}\r\n`,
-    );
-    assert.match(output, /^HTTP\/1\.1 400 Bad Request/);
-  }
-  const lf_only = await adapter_request(network, "GET / HTTP/1.1\nHost: example.test\n\n");
-  assert.match(lf_only, /^HTTP\/1\.1 400 Bad Request/);
-  assert.equal(fetched, false);
 });
 
 test("backpressures an upstream fetch response when the guest stops reading", async () => {

--- a/packages/linux-guest/tests/fixture.ts
+++ b/packages/linux-guest/tests/fixture.ts
@@ -25,15 +25,18 @@ export function guest_test(
 ) {
   test(name, async (t) => {
     const network = createNetwork({
-      async connectTcp({ hostname, port }) {
-        const socket = createConnection({ host: hostname, port });
+      async connectTcp(session) {
+        const socket = createConnection({
+          host: session.target.hostname,
+          port: session.target.port,
+          signal: session.signal,
+        });
         await once(socket, "connect");
         const streams = Duplex.toWeb(socket);
-        return {
-          readable: streams.readable as ReadableStream<Uint8Array>,
-          writable: streams.writable as WritableStream<Uint8Array>,
-          close: () => socket.destroy(),
-        };
+        await Promise.all([
+          session.readable.pipeTo(streams.writable as WritableStream<Uint8Array>),
+          (streams.readable as ReadableStream<Uint8Array>).pipeTo(session.writable),
+        ]);
       },
       resolveDns: resolve4,
     });

--- a/packages/linux-guest/tests/fuzz.ts
+++ b/packages/linux-guest/tests/fuzz.ts
@@ -1,0 +1,332 @@
+// Deterministic corpus generation for the HTTP differential and property
+// tests. Everything is seeded so a failing case reproduces from the seed and
+// index alone; the tests never depend on ambient randomness.
+
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function pick<T>(random: () => number, options: readonly T[]): T {
+  return options[Math.floor(random() * options.length)]!;
+}
+
+export function int(random: () => number, min: number, max: number) {
+  return min + Math.floor(random() * (max - min + 1));
+}
+
+/** Random bytes over a few distinct byte distributions. */
+export function random_bytes(random: () => number, length: number): Uint8Array {
+  const mode = Math.floor(random() * 4);
+  const bytes = new Uint8Array(length);
+  for (let index = 0; index < length; index++) {
+    switch (mode) {
+      case 0:
+        bytes[index] = int(random, 0, 255);
+        break;
+      case 1:
+        bytes[index] = int(random, 0, 0x0f);
+        break;
+      case 2:
+        bytes[index] = index & 0xff;
+        break;
+      case 3:
+        bytes[index] = pick(random, [0, 0x0a, 0x0d, 0x09, 0x20, 0x2c]);
+        break;
+    }
+  }
+  return bytes;
+}
+
+/** Splits `bytes` into random-size pieces, for feeding streams incrementally. */
+export function split_bytes(random: () => number, bytes: Uint8Array): Uint8Array[] {
+  const pieces: Uint8Array[] = [];
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const length = int(random, 1, Math.max(1, bytes.byteLength - offset));
+    pieces.push(bytes.subarray(offset, offset + length));
+    offset += length;
+  }
+  return pieces;
+}
+
+const HEADER_NAMES = [
+  "Accept",
+  "Accept-Encoding",
+  "Cache-Control",
+  "Content-Type",
+  "User-Agent",
+  "X-Request-ID",
+  "X-Custom-Header",
+];
+
+const HEADER_VALUES = [
+  "text/html",
+  "text/plain; charset=utf-8",
+  "application/json",
+  "gzip, deflate",
+  "no-cache",
+  "test-agent/1.0",
+  "a1b2c3d4",
+  "some value with spaces",
+];
+
+const HOSTS = ["example.test", "www.example.test", "api.example.net", "cdn.example.org"];
+
+const TARGETS = [
+  "/",
+  "/index.html",
+  "/api/v1/items?page=2",
+  "/a/b/c/d",
+  "/search?q=hello+world&n=10",
+  "/favicon.ico",
+];
+
+const METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"];
+
+const CRLF = "\r\n";
+
+/**
+ * Grammar-generated chunked transfer coding for `payload`: random chunk
+ * sizes, and optionally extensions, uppercase sizes, and trailer fields.
+ */
+export function chunked_frame(
+  random: () => number,
+  payload: Uint8Array,
+  options: { uppercase?: boolean; trailers?: boolean; extensions?: boolean } = {},
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  let offset = 0;
+  while (offset < payload.byteLength) {
+    const length = int(random, 1, Math.max(1, payload.byteLength - offset));
+    let size = length.toString(16);
+    if (options.uppercase) size = size.toUpperCase();
+    if (options.extensions && random() < 0.3) size += `;ext=${int(random, 0, 9)}`;
+    parts.push(encoder.encode(`${size}\r\n`));
+    parts.push(payload.subarray(offset, offset + length));
+    parts.push(encoder.encode("\r\n"));
+    offset += length;
+  }
+  parts.push(encoder.encode("0\r\n"));
+  if (options.trailers && random() < 0.5) parts.push(encoder.encode("x-trailer: value\r\n"));
+  parts.push(encoder.encode("\r\n"));
+  const total = parts.reduce((sum, part) => sum + part.byteLength, 0);
+  const bytes = new Uint8Array(total);
+  let position = 0;
+  for (const part of parts) {
+    bytes.set(part, position);
+    position += part.byteLength;
+  }
+  return bytes;
+}
+
+/**
+ * A request both Node's parser and the fetch adapter must accept: strict
+ * CRLF, exactly one clean Host, well-formed framing, no upgrades.
+ */
+export function valid_request(random: () => number): Uint8Array {
+  const method = pick(random, METHODS);
+  const with_body = method !== "GET" && method !== "HEAD" && random() < 0.6;
+  const body = with_body
+    ? random_bytes(random, pick(random, [1, 5, 100, 1024, 16 * 1024]))
+    : new Uint8Array();
+  const chunked = with_body && random() < 0.5;
+  const expect = with_body && !chunked && random() < 0.15;
+  const connection = pick(random, ["close", "close", "x-private"]);
+  const headers = [
+    `Host: ${pick(random, HOSTS)}`,
+    `Connection: ${connection}`,
+    "User-Agent: fuzz-agent/1.0",
+  ];
+  if (connection === "x-private") headers.push("X-Private: secret");
+  const extra = new Set<string>();
+  for (let count = int(random, 0, 3); count > 0; count--) {
+    const name = pick(random, HEADER_NAMES);
+    if (extra.has(name)) continue;
+    extra.add(name);
+    headers.push(`${name}: ${pick(random, HEADER_VALUES)}`);
+  }
+  if (chunked) headers.push("Transfer-Encoding: chunked");
+  else if (with_body || method !== "GET") headers.push(`Content-Length: ${body.byteLength}`);
+  else headers.push("Content-Length: 0");
+  if (expect) headers.push("Expect: 100-continue");
+  const head = `${method} ${pick(random, TARGETS)} HTTP/1.1${CRLF}${headers.join(CRLF)}${CRLF}${CRLF}`;
+  const encoder = new TextEncoder();
+  const head_bytes = encoder.encode(head);
+  const body_bytes = chunked ? chunked_frame(random, body) : body;
+  const bytes = new Uint8Array(head_bytes.byteLength + body_bytes.byteLength);
+  bytes.set(head_bytes);
+  bytes.set(body_bytes, head_bytes.byteLength);
+  return bytes;
+}
+
+const WEIRD_HOSTS = [
+  "user@example.test",
+  "EXAMPLE.TEST",
+  "example.test:8080",
+  "example.test/evil",
+  "a b.test",
+  "",
+  "exa\tmple.test",
+  "example.test\\path",
+  "exam ple.test",
+  "example.test?query",
+];
+
+const EVIL_FRAMING = [
+  "Content-Length: +5",
+  "Content-Length:  5",
+  "Content-Length: 0x10",
+  "Content-Length: 1e3",
+  "Content-Length: -5",
+  "Content-Length: 99999999999999999999",
+  "Content-Length: 5\r\nContent-Length: 5",
+  "Content-Length: 5\r\nContent-Length: 6",
+  "Content-Length: 5\r\nTransfer-Encoding: chunked",
+  "Transfer-Encoding: gzip",
+  "Transfer-Encoding: chunked\r\nTransfer-Encoding: chunked",
+];
+
+const WEIRD_TARGETS = ["/a\\b", "/hash#frag", "/space here", "*", "http://example.test/path"];
+
+const WEIRD_LINES = ["GET / HTTP/1.0", "get / HTTP/1.1", "GET / HTTP/2.0"];
+
+/**
+ * A request outside the adapter's strict contract: Node's parser may accept
+ * it, so the differential only demands rejection agreement and safety.
+ */
+export function edge_request(random: () => number): Uint8Array {
+  const encoder = new TextEncoder();
+  const mode = int(random, 0, 10);
+  const host = pick(random, WEIRD_HOSTS);
+  switch (mode) {
+    case 0:
+      return encoder.encode(
+        `GET / HTTP/1.1${CRLF}Host: ${host}${CRLF}Connection: keep-alive${CRLF}${CRLF}`,
+      );
+    case 1:
+      return encoder.encode(
+        `GET / HTTP/1.1${CRLF}Host: example.test${CRLF}Upgrade: websocket${CRLF}Connection: Upgrade${CRLF}${CRLF}`,
+      );
+    case 2:
+      return encoder.encode(
+        `POST / HTTP/1.1${CRLF}Host: example.test${CRLF}Expect: 100-nonsense${CRLF}Content-Length: 5${CRLF}${CRLF}hello`,
+      );
+    case 3:
+      return encoder.encode(
+        `POST / HTTP/1.1${CRLF}Host: example.test${CRLF}Expect: 100-continue${CRLF}Content-Length: 5${CRLF}${CRLF}hello`,
+      );
+    case 4:
+      return encoder.encode(
+        `POST / HTTP/1.1${CRLF}Host: example.test${CRLF}${pick(random, EVIL_FRAMING)}${CRLF}${CRLF}hello`,
+      );
+    case 5:
+      return encoder.encode(`GET / HTTP/1.1\nHost: example.test\n\n`);
+    case 6:
+      return encoder.encode(`GET / HTTP/1.1\r\nHost: example.test\n\n`);
+    case 7:
+      return encoder.encode(`GET ${pick(random, WEIRD_TARGETS)} HTTP/1.1${CRLF}Host: example.test${CRLF}${CRLF}`);
+    case 8:
+      return encoder.encode(`${pick(random, WEIRD_LINES)}${CRLF}Host: example.test${CRLF}${CRLF}`);
+    case 9:
+      return encoder.encode(
+        `CONNECT ${pick(random, ["example.test:443", "/tunnel"])} HTTP/1.1${CRLF}Host: example.test${CRLF}${CRLF}`,
+      );
+    default:
+      return encoder.encode(
+        `GET / HTTP/1.1${CRLF}Host: ${host}${CRLF}X-Dup: a${CRLF}X-Dup: b${CRLF}${CRLF}`,
+      );
+  }
+}
+
+/** Byte-level mutations of a valid request. */
+export function mutant(random: () => number, base: Uint8Array): Uint8Array {
+  const bytes = base.slice();
+  const ops = int(random, 1, 3);
+  for (let count = 0; count < ops; count++) {
+    switch (int(random, 0, 5)) {
+      case 0: {
+        const index = int(random, 0, bytes.byteLength - 1);
+        bytes[index]! ^= 1 << int(random, 0, 7);
+        break;
+      }
+      case 1: {
+        const index = int(random, 0, bytes.byteLength - 1);
+        bytes.set(bytes.subarray(index + 1));
+        break;
+      }
+      case 2: {
+        const index = int(random, 0, bytes.byteLength);
+        const inserted = new Uint8Array(bytes.byteLength + 1);
+        inserted.set(bytes.subarray(0, index));
+        inserted[index] = pick(random, [0x0d, 0x0a, 0x20, 0x3a, 0x41, 0x00, 0x7f]);
+        inserted.set(bytes.subarray(index), index + 1);
+        return inserted;
+      }
+      case 3: {
+        const marker = bytes.indexOf(0x0d, int(random, 0, Math.max(0, bytes.byteLength - 1)));
+        if (marker !== -1) bytes[marker] = 0x0a;
+        break;
+      }
+      case 4: {
+        const index = int(random, 0, Math.max(0, bytes.byteLength - 1));
+        const before = bytes.subarray(0, index);
+        const after = bytes.subarray(index);
+        const doubled = new Uint8Array(before.byteLength + after.byteLength + 1);
+        doubled.set(before);
+        doubled.set([bytes[index]!], before.byteLength);
+        doubled.set(after, before.byteLength + 1);
+        return doubled;
+      }
+      case 5: {
+        const index = int(random, 0, Math.max(0, bytes.byteLength - 1));
+        const before = bytes.subarray(0, index);
+        const rest = bytes.subarray(index + 1);
+        const swapped = new Uint8Array(bytes.byteLength);
+        swapped.set(rest);
+        swapped.set(before, rest.byteLength);
+        return swapped;
+      }
+    }
+  }
+  return bytes;
+}
+
+export interface CorpusEntry {
+  readonly bytes: Uint8Array;
+  /** "valid" requests must be accepted and parsed identically by both sides. */
+  readonly kind: "valid" | "edge" | "mutant";
+}
+
+export function build_request_corpus(seed: number, scale: number): CorpusEntry[] {
+  const random = mulberry32(seed);
+  const corpus: CorpusEntry[] = [];
+  for (let count = 0; count < 600 * scale; count++) {
+    corpus.push({ bytes: valid_request(random), kind: "valid" });
+  }
+  for (let count = 0; count < 500 * scale; count++) {
+    corpus.push({ bytes: edge_request(random), kind: "edge" });
+  }
+  for (let count = 0; count < 600 * scale; count++) {
+    corpus.push({ bytes: mutant(random, valid_request(random)), kind: "mutant" });
+  }
+  return corpus;
+}
+
+/** Random header maps for serialize/parse round-trip properties. */
+export function random_headers(random: () => number): Headers {
+  const headers = new Headers();
+  for (let count = int(random, 1, 6); count > 0; count--) {
+    const name = pick(random, [...HEADER_NAMES, "X-Spaces", "Content-Length"]);
+    const value = pick(random, [...HEADER_VALUES, " padded value ", "tab\there", "caf\u00e9"]);
+    headers.set(name, value);
+  }
+  return headers;
+}

--- a/packages/linux-guest/tests/guest-fetch.test.ts
+++ b/packages/linux-guest/tests/guest-fetch.test.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { guestFetch } from "../src/guest-fetch.ts";
+import type { GuestNetwork, NetworkedGuest, TcpConnection } from "../src/index.ts";
+import { guest_test } from "./fixture.ts";
+import { connect_with_retry } from "./helpers.ts";
+
+const encoder = new TextEncoder();
+
+// tcpsvd hands the socket to the program as stdin and stdout. Draining the
+// request to EOF before replying avoids a close-with-unread-data RST that
+// would race the canned response.
+function serve(guest: NetworkedGuest, port: number, script: string) {
+  return guest.exec(["tcpsvd", "-c", "2", "0.0.0.0", String(port), "sh", "-c", script]);
+}
+
+guest_test("guest-fetch", async (t, fixture) => {
+  const guest = await fixture.spawn();
+  const fetch = guestFetch(guest.network, { port: 8080 });
+
+  // The `Network` overload must also typecheck, hostname supplied explicitly.
+  guestFetch(fixture.network, { hostname: guest.network.address, port: 80 });
+
+  await t.test("serves a site over busybox httpd", async () => {
+    await guest.fs.mkdir("/tmp/www", { recursive: true });
+    await guest.fs.writeFile("/tmp/www/index.html", encoder.encode("<h1>hello</h1>\n"));
+    const server = await guest.exec(["/usr/sbin/httpd", "-f", "-p", "8080", "-h", "/tmp/www"]);
+    try {
+      const ok = await connect_with_retry(() =>
+        fetch(new Request("http://guest.example/index.html")),
+      );
+      assert.equal(ok.status, 200);
+      assert.match(ok.headers.get("content-type") ?? "", /text\/html/);
+      assert.equal(await ok.text(), "<h1>hello</h1>\n");
+
+      const missing = await fetch(new Request("http://guest.example/nope"));
+      assert.equal(missing.status, 404);
+      await missing.text();
+
+      const head = await fetch(new Request("http://guest.example/index.html", { method: "HEAD" }));
+      assert.equal(head.status, 200);
+      assert.equal(await head.text(), "");
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("decodes a chunked response and discards trailers", async () => {
+    await guest.fs.writeFile(
+      "/tmp/chunked",
+      encoder.encode(
+        "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\ntrailer: x-sum\r\n\r\n" +
+          "5\r\nhello\r\n6\r\n world\r\n0\r\nx-sum: 42\r\n\r\n",
+      ),
+    );
+    const server = await serve(guest, 8081, "cat >/dev/null; cat /tmp/chunked");
+    const done = guestFetch(guest.network, { port: 8081 });
+    try {
+      const res = await connect_with_retry(() => done(new Request("http://guest.example/")));
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("transfer-encoding"), null);
+      assert.equal(res.headers.get("x-sum"), null);
+      assert.equal(await res.text(), "hello world");
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("reads an HTTP/1.0 close-delimited response", async () => {
+    await guest.fs.writeFile(
+      "/tmp/http10",
+      encoder.encode("HTTP/1.0 200 OK\r\ncontent-type: text/plain\r\n\r\nclose delimited body"),
+    );
+    const server = await serve(guest, 8082, "cat >/dev/null; cat /tmp/http10");
+    const done = guestFetch(guest.network, { port: 8082 });
+    try {
+      const res = await connect_with_retry(() => done(new Request("http://guest.example/")));
+      assert.equal(res.status, 200);
+      assert.equal(await res.text(), "close delimited body");
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("handles a 204 with no body", async () => {
+    await guest.fs.writeFile("/tmp/no-content", encoder.encode("HTTP/1.1 204 No Content\r\n\r\n"));
+    const server = await serve(guest, 8083, "cat >/dev/null; cat /tmp/no-content");
+    const done = guestFetch(guest.network, { port: 8083 });
+    try {
+      const res = await connect_with_retry(() => done(new Request("http://guest.example/")));
+      assert.equal(res.status, 204);
+      assert.equal(await res.text(), "");
+    } finally {
+      await server.kill();
+    }
+  });
+
+  const canned = "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n";
+
+  await t.test("serializes a bodyless GET", async () => {
+    await guest.fs.writeFile("/tmp/resp-get", encoder.encode(canned));
+    const server = await serve(guest, 8084, "cat >/tmp/cap-get; cat /tmp/resp-get");
+    const done = guestFetch(guest.network, { port: 8084 });
+    try {
+      const res = await connect_with_retry(() =>
+        done(new Request("http://guest.example/foo?bar=1")),
+      );
+      assert.equal(res.status, 200);
+      await res.text();
+      const captured = await guest.fs.readTextFile("/tmp/cap-get");
+      assert.match(captured, /^GET \/foo\?bar=1 HTTP\/1\.1\r\n/);
+      assert.match(captured, /\r\nhost: guest\.example\r\n/);
+      assert.match(captured, /\r\nconnection: close\r\n/);
+      assert.doesNotMatch(captured, /transfer-encoding|content-length/i);
+      assert.ok(captured.endsWith("\r\n\r\n"));
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("serializes a POST with a content-length body", async () => {
+    await guest.fs.writeFile("/tmp/resp-post", encoder.encode(canned));
+    const server = await serve(guest, 8085, "cat >/tmp/cap-post; cat /tmp/resp-post");
+    const done = guestFetch(guest.network, { port: 8085 });
+    try {
+      // undici only exposes content-length when the caller sets it explicitly.
+      const res = await connect_with_retry(() =>
+        done(
+          new Request("http://guest.example/submit", {
+            method: "POST",
+            body: "hello body",
+            headers: { "content-length": "10" },
+          }),
+        ),
+      );
+      assert.equal(res.status, 200);
+      await res.text();
+      const captured = await guest.fs.readTextFile("/tmp/cap-post");
+      assert.match(captured, /^POST \/submit HTTP\/1\.1\r\n/);
+      assert.match(captured, /\r\ncontent-length: 10\r\n/);
+      assert.doesNotMatch(captured, /transfer-encoding/i);
+      assert.ok(captured.endsWith("\r\n\r\nhello body"));
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("serializes a streamed body as chunked", async () => {
+    await guest.fs.writeFile("/tmp/resp-stream", encoder.encode(canned));
+    const server = await serve(guest, 8086, "cat >/tmp/cap-stream; cat /tmp/resp-stream");
+    const done = guestFetch(guest.network, { port: 8086 });
+    try {
+      const res = await connect_with_retry(() => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode("chunk-one"));
+            controller.enqueue(encoder.encode("chunk-two"));
+            controller.close();
+          },
+        });
+        // Node requires `duplex` when streaming a request body; the lib type omits it.
+        const init = { method: "POST", body, duplex: "half" } as RequestInit;
+        return done(new Request("http://guest.example/stream", init));
+      });
+      assert.equal(res.status, 200);
+      await res.text();
+      const captured = await guest.fs.readTextFile("/tmp/cap-stream");
+      assert.match(captured, /\r\ntransfer-encoding: chunked\r\n/);
+      assert.ok(captured.endsWith("9\r\nchunk-one\r\n9\r\nchunk-two\r\n0\r\n\r\n"));
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("POST echo through httpd CGI", async () => {
+    await guest.fs.mkdir("/tmp/www/cgi-bin", { recursive: true });
+    // A hush CGI script: the header block, then cat streams the request body
+    // (httpd frames CGI stdin by CONTENT_LENGTH) straight back as the response.
+    await guest.fs.writeFile(
+      "/tmp/www/cgi-bin/echo",
+      encoder.encode("#!/bin/sh\necho 'Content-type: text/plain'\necho\ncat\n"),
+    );
+    await guest.fs.chmod("/tmp/www/cgi-bin/echo", 0o755);
+    const server = await guest.exec(["/usr/sbin/httpd", "-f", "-p", "8087", "-h", "/tmp/www"]);
+    const done = guestFetch(guest.network, { port: 8087 });
+    try {
+      const res = await connect_with_retry(() =>
+        done(
+          new Request("http://guest.example/cgi-bin/echo", {
+            method: "POST",
+            body: "echo me",
+            headers: { "content-length": "7" },
+          }),
+        ),
+      );
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") ?? "", /text\/plain/);
+      assert.equal(await res.text(), "echo me");
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("returns an early final response without finishing the upload", async () => {
+    await guest.fs.writeFile(
+      "/tmp/too-large",
+      encoder.encode("HTTP/1.1 413 Content Too Large\r\ncontent-length: 0\r\n\r\n"),
+    );
+    // Exit immediately after the response without draining stdin: the complete
+    // HTTP response must win over the upload write failure caused by close.
+    const server = await serve(guest, 8088, "cat /tmp/too-large");
+    const done = guestFetch(guest.network, { port: 8088 });
+    try {
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new Uint8Array(64 * 1024));
+        },
+      });
+      const init = { method: "POST", body, duplex: "half" } as RequestInit;
+      const response = await connect_with_retry(() =>
+        done(new Request("http://guest.example/upload", init)),
+      );
+      assert.equal(response.status, 413);
+      await response.body?.cancel();
+    } finally {
+      await server.kill();
+    }
+  });
+
+  await t.test("rejects an already-aborted request before connecting", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+    await assert.rejects(
+      guestFetch(guest.network, { port: 65535 })(
+        new Request("http://guest.example/", { signal: controller.signal }),
+      ),
+      /cancelled/,
+    );
+  });
+});
+
+test("guestFetch abort cancels a stalled request body", async () => {
+  const started = Promise.withResolvers<void>();
+  const cancelled = Promise.withResolvers<unknown>();
+  let first = true;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (first) {
+        first = false;
+        controller.enqueue(new Uint8Array(1024));
+        started.resolve();
+      }
+      return new Promise(() => {});
+    },
+    cancel(reason) {
+      cancelled.resolve(reason);
+    },
+  });
+
+  let incoming!: ReadableStreamDefaultController<Uint8Array>;
+  let closed = false;
+  const address = { transport: "tcp", hostname: "192.0.2.2", port: 8080 } as const;
+  const connection: TcpConnection = {
+    readable: new ReadableStream({ start: (controller) => (incoming = controller) }),
+    writable: new WritableStream(),
+    localAddr: address,
+    remoteAddr: address,
+    close() {
+      if (closed) return;
+      closed = true;
+      incoming.error(new Error("connection closed"));
+    },
+  };
+  const network = {
+    address: address.hostname,
+    connect: (options: { signal?: AbortSignal }) => {
+      const abort = () => connection.close();
+      options.signal?.addEventListener("abort", abort, { once: true });
+      if (options.signal?.aborted) abort();
+      return Promise.resolve(connection);
+    },
+  } as unknown as GuestNetwork;
+
+  const controller = new AbortController();
+  const init = { method: "POST", body, duplex: "half", signal: controller.signal } as RequestInit;
+  const response = guestFetch(network, { port: 8080 })(new Request("http://guest/", init));
+  await started.promise;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  controller.abort(new Error("cancelled"));
+  await assert.rejects(response, /cancelled/);
+  await cancelled.promise;
+  assert.equal(closed, true);
+});

--- a/packages/linux-guest/tests/http-properties.test.ts
+++ b/packages/linux-guest/tests/http-properties.test.ts
@@ -1,0 +1,214 @@
+// Property tests over the pure HTTP layer in src/http.ts: round-trips and
+// grammar-based generation cover far more byte sequences than hand-written
+// cases, and malformed inputs must reject rather than hang or crash.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  ByteReader,
+  chunked_body,
+  chunked_encoder,
+  declared_body,
+  declared_raw_body,
+  fixed_body,
+  parse_request_line,
+  parse_status_line,
+  serialize_head,
+  strip_hop_by_hop,
+} from "../src/http.ts";
+import { chunked_frame, int, mulberry32, random_bytes, random_headers, split_bytes } from "./fuzz.ts";
+import { collect } from "./helpers.ts";
+
+const encoder = new TextEncoder();
+
+function source(bytes: Uint8Array, pieces: Uint8Array[] = [bytes]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    async start(controller) {
+      for (const piece of pieces) {
+        controller.enqueue(piece);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      controller.close();
+    },
+  });
+}
+
+test("chunked encode/decode is an identity", async () => {
+  const random = mulberry32(0xfeed);
+  for (const length of [0, 1, 17, 4096, 65536]) {
+    for (let count = 0; count < 4; count++) {
+      const payload = random_bytes(random, length);
+      const encoded = new ReadableStream({
+        start(controller) {
+          controller.enqueue(payload);
+          controller.close();
+        },
+      }).pipeThrough(chunked_encoder());
+      const decoded = chunked_body(new ByteReader(encoded));
+      assert.deepEqual(await collect(decoded), payload);
+    }
+  }
+});
+
+test("grammar-generated chunked frames decode to their payload", async () => {
+  const random = mulberry32(0xc0ffee);
+  for (let count = 0; count < 40; count++) {
+    const payload = random_bytes(random, int(random, 0, 32768));
+    const frame = chunked_frame(random, payload, {
+      uppercase: random() < 0.5,
+      trailers: random() < 0.5,
+      extensions: random() < 0.5,
+    });
+    const decoded = chunked_body(new ByteReader(source(frame, split_bytes(random, frame))));
+    assert.deepEqual(await collect(decoded), payload);
+  }
+});
+
+test("chunked decoder rejects malformed frames", async () => {
+  const cases = [
+    "zz\r\npayload\r\n0\r\n\r\n",
+    "-1\r\npayload\r\n0\r\n\r\n",
+    "5\r\nhel",
+    "5\r\nhello\r\nzz\r\nx\r\n0\r\n\r\n",
+    "10000000000000000\r\nx",
+    "5\r\nhello",
+    "0\r\n",
+    "5\r\nhello\r\n0\r\n",
+  ];
+  for (const text of cases) {
+    await assert.rejects(collect(chunked_body(new ByteReader(source(encoder.encode(text))))));
+  }
+});
+
+test("serialized heads parse back to the same headers", async () => {
+  const random = mulberry32(0x1234);
+  for (let count = 0; count < 50; count++) {
+    const headers = random_headers(random);
+    const line = "GET /a/b?q=1 HTTP/1.1";
+    const head = await new ByteReader(source(serialize_head(line, headers))).head();
+    assert.ok(head);
+    assert.equal(head.line, line);
+    const expected = new Map<string, string>();
+    for (const [name, value] of headers) expected.set(name.toLowerCase(), value.trim());
+    const actual = new Map(head.rawHeaders.map(([name, value]) => [name.toLowerCase(), value]));
+    assert.deepEqual(actual, expected);
+  }
+});
+
+test("request and status lines parse strictly", () => {
+  const requests: [string, { method: string; target: string }][] = [
+    ["GET / HTTP/1.1", { method: "GET", target: "/" }],
+    ["POST /a?b=1 HTTP/1.0", { method: "POST", target: "/a?b=1" }],
+    ["DELETE /x/y HTTP/1.1", { method: "DELETE", target: "/x/y" }],
+  ];
+  for (const [line, expected] of requests) {
+    assert.deepEqual(parse_request_line(line), expected);
+  }
+  for (const line of [
+    "get / HTTP/1.1",
+    "GET  HTTP/1.1",
+    "GET / HTTP/2.0",
+    "GET * HTTP/1.1",
+    "GET http://x/ HTTP/1.1",
+    "GET / HTTP/1.1 extra",
+  ]) {
+    assert.throws(() => parse_request_line(line));
+  }
+  const statuses: [string, { status: number; text: string }][] = [
+    ["HTTP/1.1 200 OK", { status: 200, text: "OK" }],
+    ["HTTP/1.0 404 Not Found", { status: 404, text: "Not Found" }],
+    ["HTTP/1.1 204 ", { status: 204, text: "" }],
+  ];
+  for (const [line, expected] of statuses) {
+    assert.deepEqual(parse_status_line(line), expected);
+  }
+  for (const line of ["HTTP/1.1 20 OK", "HTTP/1.1 2000 OK", "HTTP/2.0 200 OK", "HTTP/1.1 abc OK"]) {
+    assert.throws(() => parse_status_line(line));
+  }
+});
+
+test("declared body framing follows one obvious rule", async () => {
+  const with_headers = (...pairs: [string, string][]) => {
+    const headers = new Headers();
+    for (const [name, value] of pairs) headers.append(name, value);
+    return headers;
+  };
+  assert.equal(declared_body(with_headers(["content-length", "5"])), 5);
+  assert.equal(declared_body(with_headers(["content-length", "0"])), 0);
+  assert.equal(declared_body(with_headers()), undefined);
+  assert.equal(declared_body(with_headers(["transfer-encoding", "chunked"])), "chunked");
+  for (const pairs of [
+    [["content-length", "5"], ["transfer-encoding", "chunked"]],
+    [["transfer-encoding", "gzip"]],
+    [["content-length", "1e3"]],
+    [["content-length", "18446744073709551616"]],
+    [["content-length", "-1"]],
+  ]) {
+    assert.throws(() => declared_body(with_headers(...(pairs as [string, string][]))));
+  }
+  // Duplicate framing must be rejected on the raw wire fields, before the
+  // Headers class can combine them.
+  const head = await new ByteReader(
+    source(encoder.encode("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\nhello")),
+  ).head();
+  assert.ok(head);
+  assert.throws(() => declared_raw_body(head));
+});
+
+test("fixed bodies deliver exactly the declared bytes", async () => {
+  const random = mulberry32(0xbeef);
+  for (let count = 0; count < 10; count++) {
+    const length = int(random, 0, 8192);
+    const payload = random_bytes(random, length);
+    const body = fixed_body(new ByteReader(source(payload, split_bytes(random, payload))), length);
+    assert.deepEqual(await collect(body), payload);
+  }
+  const short = fixed_body(new ByteReader(source(random_bytes(random, 3))), 5);
+  await assert.rejects(collect(short));
+});
+
+test("ByteReader enforces its head and line limits", async () => {
+  const big_head = encoder.encode(`GET / HTTP/1.1\r\nX-Junk: ${"a".repeat(70000)}\r\n\r\n`);
+  await assert.rejects(new ByteReader(source(big_head)).head(), /HTTP head too large/);
+  const long_line = encoder.encode(`GET / HTTP/1.1\r\nX-Junk: ${"a".repeat(9000)}\r\n\r\n`);
+  const reader = new ByteReader(source(long_line));
+  assert.equal(await reader.line(), "GET / HTTP/1.1");
+  await assert.rejects(reader.line(), /HTTP line too long/);
+});
+
+test("strip_hop_by_hop removes connection-scoped fields", () => {
+  const headers = new Headers({
+    connection: "x-private, keep-alive",
+    "x-private": "secret",
+    "keep-alive": "timeout=5",
+    te: "trailers",
+    "transfer-encoding": "chunked",
+    upgrade: "h2c",
+    "x-keep": "yes",
+  });
+  strip_hop_by_hop(headers);
+  for (const name of ["connection", "x-private", "keep-alive", "te", "trailer", "transfer-encoding", "upgrade"]) {
+    assert.equal(headers.get(name), null);
+  }
+  assert.equal(headers.get("x-keep"), "yes");
+  const bad = new Headers({ connection: "bad token!" });
+  assert.throws(() => strip_hop_by_hop(bad));
+});
+
+test("malformed heads reject; empty input ends cleanly", async () => {
+  assert.equal(await new ByteReader(source(new Uint8Array())).head(), undefined);
+  for (const text of [
+    "GET / HTTP/1.1\r\nX Bad: v\r\n\r\n",
+    "GET / HTTP/1.1\r\nHost x\r\n\r\n",
+    "GET / HTTP/1.1\r\n: value\r\n\r\n",
+    "GET / HTTP/1.1\r\nHost: x",
+  ]) {
+    await assert.rejects(new ByteReader(source(encoder.encode(text))).head());
+  }
+  await assert.rejects(
+    new ByteReader(source(encoder.encode("GET / HTTP/1.1\n\r\n\r\n")), { strictCrlf: true }).head(),
+    /HTTP requires CRLF/,
+  );
+  // A truncated body rejects once the declared length is read.
+  await assert.rejects(collect(fixed_body(new ByteReader(source(encoder.encode("he"))), 5)));
+});


### PR DESCRIPTION

Add reusable HTTP/1 adapters in both directions: expose a guest listener as a fetch-like handler, and satisfy guest HTTP connections with a host Fetch implementation.

The shared protocol layer validates framing and authority, strips hop-by-hop headers, bounds parsing and uploads, streams with backpressure, and closes resources on completion, cancellation, or abort. Add integration coverage for fixed, chunked, and close-delimited bodies, interim and early responses, malformed framing, security boundaries, backpressure, and lifecycle cleanup.

Amp-Thread: https://ampcode.com/threads/T-019fb06f-4fb5-723b-92e2-40857521694d

<!-- jj-pr stack navigation -->
## Stack
- https://github.com/tombl/distro/pull/121 :point_left:
- https://github.com/tombl/distro/pull/122
<!-- /jj-pr stack navigation -->