### PR TITLE
ports: add Bash without replacing BusyBox sh

### DIFF
--- a/distro/bash/bash-clone.c
+++ b/distro/bash/bash-clone.c
@@ -1,0 +1,30 @@
+#define _GNU_SOURCE
+
+#include "bash-clone.h"
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdlib.h>
+
+pid_t
+bash_clone (int (*child_func) (void *), void *arg)
+{
+  /* Unlike the shallow callback clones in other ports, Bash can run arbitrary
+     recursive shell code here.  Match the platform's ordinary process stack. */
+  enum { CHILD_STACK_SIZE = 8 * 1024 * 1024 };
+  void *child_stack;
+  pid_t pid;
+  int errno_save;
+
+  child_stack = malloc (CHILD_STACK_SIZE);
+  if (child_stack == NULL)
+    return -1;
+
+  pid = clone (child_func, (char *)child_stack + CHILD_STACK_SIZE, SIGCHLD,
+               arg);
+  errno_save = errno;
+  free (child_stack);
+  errno = errno_save;
+  return pid;
+}

--- a/distro/bash/bash-clone.h
+++ b/distro/bash/bash-clone.h
@@ -1,0 +1,8 @@
+#ifndef BASH_CLONE_H
+#define BASH_CLONE_H
+
+#include <sys/types.h>
+
+pid_t bash_clone (int (*) (void *), void *);
+
+#endif

--- a/distro/bash/fork-shim.c
+++ b/distro/bash/fork-shim.c
@@ -1,0 +1,18 @@
+#include <sys/types.h>
+#include <unistd.h>
+
+/*
+ * Link-only guard for fork sites that have not yet been converted to the
+ * callback form required by wasm Linux.  This must stay loud: returning an
+ * error would make Bash silently take ordinary fork-failure paths and hide an
+ * unsupported execution shape.
+ */
+pid_t
+fork (void)
+{
+  static const char message[] =
+    "bash: unconverted fork() call reached on wasm Linux\n";
+
+  (void)write (STDERR_FILENO, message, sizeof (message) - 1);
+  __builtin_trap ();
+}

--- a/distro/bash/functional-test.sh
+++ b/distro/bash/functional-test.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# shellcheck disable=SC2030,SC2031,SC2116
+
+fail() {
+  printf 'bash functional failure: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $BASH_VERSION == 5.3.9* ]] || fail "BASH_VERSION patchlevel: $BASH_VERSION"
+
+sum=0
+for number in 1 2 3 4; do
+  sum=$((sum + number))
+done
+[[ $sum -eq 10 ]] || fail "for loop or arithmetic expansion"
+
+case_word=banana
+case $case_word in
+b*n*n*) case_result=matched ;;
+*) case_result=missed ;;
+esac
+[[ $case_result == matched ]] || fail "case pattern"
+
+counter=0
+while [[ $counter -lt 3 ]]; do
+  ((counter += 1))
+done
+[[ $counter -eq 3 ]] || fail "while loop or arithmetic command"
+
+indexed=(zero one)
+indexed[3]=three
+[[ ${indexed[0]} == zero && ${indexed[3]} == three ]] || fail "indexed arrays"
+[[ ${#indexed[@]} -eq 3 ]] || fail "sparse indexed array length"
+
+declare -A associated=([alpha]=one [beta]=two)
+[[ ${associated[alpha]} == one && ${associated[beta]} == two ]] ||
+  fail "associative arrays"
+
+conditional_value=foobar
+[[ $conditional_value == f* && $conditional_value =~ ^foo ]] ||
+  fail "extended conditional"
+
+source_value=banana
+[[ ${source_value//a/A} == bAnAnA ]] || fail "global parameter substitution"
+
+printf -v formatted '%s:%02d' value 7
+[[ $formatted == value:07 ]] || fail "printf -v"
+
+function exercise_scope() {
+  local local_value=inside
+  declare -i declared_number=6
+  declared_number+=1
+  printf -v scoped_result '%s:%d' "$local_value" "$declared_number"
+}
+
+exercise_scope
+[[ $scoped_result == inside:7 ]] || fail "function, local, or declare"
+[[ ! -v local_value && ! -v declared_number ]] || fail "local variable leaked"
+
+arithmetic_result=$((6 * 7))
+[[ $arithmetic_result -eq 42 ]] || fail "arithmetic expansion"
+
+# These assignments are intentionally isolated by two different child forms.
+outer=parent
+subshell_value=$(
+  outer=command-substitution
+  printf '%s' "$outer"
+)
+[[ $outer == parent && $subshell_value == command-substitution ]] ||
+  fail "command substitution isolation"
+
+nested=$(printf '%s' "$(printf '%s' "$(printf deep)")")
+[[ $nested == deep ]] || fail "nested command substitution"
+
+# Reaping the external command must not discard the process record created by
+# the next command substitution.
+/bin/true "$(echo first)"
+substitution_after_external=$(echo second)
+substitution_status=$?
+[[ $substitution_after_external == second && $substitution_status -eq 0 ]] ||
+  fail "command substitution after external command: value=[$substitution_after_external] status=$substitution_status"
+
+if ! diff <(printf 'same\ncontent\n') <(printf 'same\ncontent\n'); then
+  fail "input process substitution"
+fi
+
+printf 'writer-data\n' > >(cat >/tmp/bash-process-substitution-writer)
+wait
+read -r process_writer </tmp/bash-process-substitution-writer
+[[ $process_writer == writer-data ]] || fail "output process substitution"
+
+# This descriptor originates in the parent shell, crosses the process-
+# substitution clone, and remains readable after its command execs cat.
+printf 'inherited-fd\n' >/tmp/bash-inherited-fd
+exec 9</tmp/bash-inherited-fd
+inherited_fd=$(cat <(cat /dev/fd/9))
+exec 9<&-
+[[ $inherited_fd == inherited-fd ]] ||
+  fail "inherited descriptor through process substitution and exec"
+
+coproc ROUNDTRIP {
+  for _ in 1 2; do
+    IFS= read -r coproc_request || exit
+    printf 'reply:%s\n' "$coproc_request"
+  done
+}
+coprocess_pid=$ROUNDTRIP_PID
+[[ $coprocess_pid =~ ^[0-9]+$ && $coprocess_pid -eq $! ]] ||
+  fail "coprocess PID variable"
+exec {coprocess_read}<&"${ROUNDTRIP[0]}"
+exec {coprocess_write}>&"${ROUNDTRIP[1]}"
+printf 'one\n' >&"$coprocess_write"
+IFS= read -r coprocess_reply_one <&"$coprocess_read"
+printf 'two\n' >&"$coprocess_write"
+IFS= read -r coprocess_reply_two <&"$coprocess_read"
+wait "$coprocess_pid" || fail "waiting for coprocess"
+exec {coprocess_read}<&-
+exec {coprocess_write}>&-
+[[ $coprocess_reply_one == reply:one && $coprocess_reply_two == reply:two ]] ||
+  fail "bidirectional coprocess I/O"
+
+outer=parent
+(
+  outer=subshell
+  [[ $outer == subshell ]]
+) || fail "subshell execution"
+[[ $outer == parent ]] || fail "subshell isolation"
+
+deep_recurse() {
+  local depth=$1
+  ((depth == 0)) || deep_recurse "$((depth - 1))"
+}
+
+(deep_recurse 300) || fail "300-level recursion in subshell"
+
+pipeline_output=$(printf 'pipeline-data\n' | cat)
+[[ $pipeline_output == pipeline-data ]] || fail "pipeline data flow"
+
+/bin/false | /bin/true
+pipeline_status=("${PIPESTATUS[@]}")
+[[ ${pipeline_status[0]} -eq 1 && ${pipeline_status[1]} -eq 0 ]] ||
+  fail "PIPESTATUS"
+
+set -o pipefail
+/bin/false | /bin/true
+pipefail_status=$?
+set +o pipefail
+[[ $pipefail_status -eq 1 ]] || fail "pipefail status"
+
+# A pipeline child begins on a callback-clone stack. Expansion errors and
+# function exits must resolve through recovery frames created on that stack.
+readonly readonly_pipeline_value=parent
+set -o pipefail
+# shellcheck disable=SC2034,SC2036 # Assignment failure is the pipeline command under test.
+readonly_pipeline_value=child | cat
+readonly_pipeline_result=("$?" "${PIPESTATUS[@]}")
+set +o pipefail
+[[ ${readonly_pipeline_result[0]} -eq 1 ]] ||
+  fail "readonly assignment pipeline status: ${readonly_pipeline_result[0]}"
+[[ ${readonly_pipeline_result[1]} -eq 1 && ${readonly_pipeline_result[2]} -eq 0 ]] ||
+  fail "readonly assignment PIPESTATUS: ${readonly_pipeline_result[*]:1}"
+
+pipeline_exit_function() {
+  exit 37
+}
+set -o pipefail
+pipeline_exit_function | cat
+pipeline_function_result=("$?" "${PIPESTATUS[@]}")
+set +o pipefail
+[[ ${pipeline_function_result[0]} -eq 37 ]] ||
+  fail "piped function exit status: ${pipeline_function_result[0]}"
+[[ ${pipeline_function_result[1]} -eq 37 && ${pipeline_function_result[2]} -eq 0 ]] ||
+  fail "piped function PIPESTATUS: ${pipeline_function_result[*]:1}"
+
+# Linux returns ENOEXEC for executable text without a shebang. Bash must
+# restart that file as a shell script from the clone stack.
+printf '%s\n' 'printf "%s\\n" shebangless-ok' >/tmp/bash-shebangless
+chmod +x /tmp/bash-shebangless
+shebangless_output=$(/tmp/bash-shebangless)
+shebangless_status=$?
+[[ $shebangless_status -eq 0 && $shebangless_output == shebangless-ok ]] ||
+  fail "shebang-less script: status=$shebangless_status output=[$shebangless_output]"
+
+# shellcheck disable=SC2329 # Bash invokes this hook by its reserved name.
+command_not_found_handle() {
+  exit 43
+}
+missing-command-for-bash-test
+notfound_hook_status=$?
+unset -f command_not_found_handle
+[[ $notfound_hook_status -eq 43 ]] ||
+  fail "command_not_found_handle exit status: $notfound_hook_status"
+
+# lastpipe represents the in-process final command as a synthetic wait status.
+# The target wait status stores the exit byte at bit offset 8.
+lastpipe_return_42() {
+  return 42
+}
+shopt -s lastpipe
+printf 'lastpipe\n' | lastpipe_return_42
+lastpipe_status=$?
+shopt -u lastpipe
+[[ $lastpipe_status -eq 42 ]] || fail "lastpipe function status: $lastpipe_status"
+
+rtmin_trap_seen=0
+trap 'rtmin_trap_seen=1' RTMIN || fail "installing RTMIN trap"
+kill -RTMIN "$$" || fail "delivering RTMIN"
+[[ $rtmin_trap_seen -eq 1 ]] || fail "RTMIN trap was not run"
+trap - RTMIN
+
+printf -v printf_hex_float '%a' 1.5 || fail "builtin printf %a"
+[[ $printf_hex_float == 0x*p* ]] ||
+  fail "builtin printf %a output: [$printf_hex_float]"
+
+read -r heredoc_line <<EOF
+expanded-$arithmetic_result
+EOF
+[[ $heredoc_line == expanded-42 ]] || fail "expanded here-document"
+
+read -r herestring_line <<<"here-string"
+[[ $herestring_line == here-string ]] || fail "here-string"
+
+# An input redirection on a command with no words sets execute_null_command's
+# forcefork safety path; it must run through the callback continuation.
+# shellcheck disable=SC2188 # The commandless redirection is the behavior under test.
+if ! </dev/null; then
+  fail "forced-child redirection-only command"
+fi
+
+cat_output=$(
+  cat <<'EOF'
+external here-document
+EOF
+)
+[[ $cat_output == "external here-document" ]] ||
+  fail "here-document redirected to external command"
+
+(
+  trap 'printf "%s\n" exit-trap >/tmp/bash-exit-trap' EXIT
+  :
+)
+read -r exit_trap_value </tmp/bash-exit-trap
+[[ $exit_trap_value == exit-trap ]] || fail "EXIT trap"
+
+usr1_value=pending
+trap 'usr1_value=delivered' USR1
+# Bracket delivery so the parent is blocked in wait and the sender is still live.
+(
+  sleep 1
+  kill -USR1 "$$"
+  sleep 1
+) &
+signal_child=$!
+wait "$signal_child"
+signal_wait_status=$?
+[[ $usr1_value == delivered ]] || fail "SIGUSR1 trap"
+[[ $signal_wait_status -gt 128 ]] ||
+  fail "wait was not interrupted by trapped SIGUSR1: $signal_wait_status"
+wait "$signal_child" || fail "reaping SIGUSR1 sender after interrupted wait"
+trap - USR1
+
+printf 'bash functional checks passed\n'

--- a/distro/bash/interactive-test.sh
+++ b/distro/bash/interactive-test.sh
@@ -1,0 +1,58 @@
+#!/bin/busybox sh
+# shellcheck disable=SC2016
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  printf '%s\n' "::vm-test::fail: $*"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+export TERM=xterm
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mkdir -p /dev/pts || fail "creating /dev/pts failed"
+mount -t devpts devpts /dev/pts || fail "mounting devpts failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+[ -f /share/terminfo/x/xterm ] ||
+  fail "Bash fragment did not ship xterm terminfo"
+
+{
+  printf '%s\n' 'case $- in *i*) printf "%s\n" interactive >/tmp/interactive ;; *) printf "%s\n" noninteractive >/tmp/interactive ;; esac'
+  printf '%s\n' 'sleep 100 &'
+  printf '%s\n' 'job_pid=$!'
+  printf '%s\n' 'printf "%s\n" "$job_pid" >/tmp/job-pid'
+  printf '%s\n' 'jobs -l'
+  printf '%s\n' 'jobs -p >/tmp/jobs-before'
+  printf '%s\n' 'kill %1'
+  printf '%s\n' 'wait "$job_pid"'
+  printf '%s\n' 'printf "%s\n" "$?" >/tmp/wait-status'
+  printf '%s\n' 'jobs -p >/tmp/jobs-after'
+  printf '%s\n' 'exit'
+} >/tmp/bash-input
+
+script -q -c '/bin/bash --noprofile --norc -i' /tmp/transcript \
+  </tmp/bash-input >/tmp/script-output 2>&1 ||
+  fail "PTY driver failed: $(cat /tmp/script-output)"
+
+grep -qx interactive /tmp/interactive ||
+  fail "Bash did not enter interactive mode: $(cat /tmp/interactive)"
+
+job_pid=$(cat /tmp/job-pid) || fail "reading background job pid failed"
+[ "$job_pid" -gt 1 ] || fail "invalid background job pid: $job_pid"
+grep -qx "$job_pid" /tmp/jobs-before ||
+  fail "jobs -p did not list $job_pid: $(cat /tmp/jobs-before)"
+[ ! -s /tmp/jobs-after ] ||
+  fail "killed job remains in jobs output: $(cat /tmp/jobs-after)"
+
+wait_status=$(cat /tmp/wait-status) || fail "reading wait status failed"
+[ "$wait_status" -eq 143 ] ||
+  fail "waiting for killed job returned $wait_status, expected 143"
+
+grep -q 'Running.*sleep 100' /tmp/transcript ||
+  fail "jobs -l did not report the running sleep: $(cat /tmp/transcript)"
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/distro/bash/package.nix
+++ b/distro/bash/package.nix
@@ -1,0 +1,214 @@
+{
+  pkgs,
+  stdenv,
+  src ? pkgs.fetchzip {
+    url = "https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz";
+    hash = "sha256-yDRoQcHzXgMUcaxNq9WMezU6zwzZp4Z4T2oD2qyfHK4=";
+  },
+  readline,
+  ncurses,
+  vm-test,
+  busybox,
+  bzip2,
+}:
+
+let
+  # Official GNU Bash 5.3 patch series, fetched the same way as nixpkgs.
+  gnuPatches =
+    map
+      (
+        patch:
+        pkgs.fetchurl {
+          url = "mirror://gnu/bash/bash-5.3-patches/bash53-${patch.number}";
+          inherit (patch) hash;
+        }
+      )
+      [
+        {
+          number = "001";
+          hash = "sha256-H2CENDZK+GubRciw6j+zsWX7gw0naX5s38esF97jKH8=";
+        }
+        {
+          number = "002";
+          hash = "sha256-44VUigATB2XseTilb73KUkR6tB+ryVol8ZreUn4oIAE=";
+        }
+        {
+          number = "003";
+          hash = "sha256-8kXZx9w/WiDYS1PSSTNHR5QJNvCdyX4dy4n8OrN9YO0=";
+        }
+        {
+          number = "004";
+          hash = "sha256-lZHSRQRVKfMvCBL5QYC52c6QI/WnZcA5uFLl38mXR9A=";
+        }
+        {
+          number = "005";
+          hash = "sha256-zKHvUtu/QzvJjjMmm2SyyBQCjv4lOL4eLJo3fakLyZ0=";
+        }
+        {
+          number = "006";
+          hash = "sha256-KRGa3e/tjv+Rrjf9UYIsMXgO4w1KKDdulgAnBsmV/xA=";
+        }
+        {
+          number = "007";
+          hash = "sha256-wJdrv/+hRTx8/dYgWPIGoxhWj/LWkPXU+gSHk/o+spk=";
+        }
+        {
+          number = "008";
+          hash = "sha256-CXzXI8v7iQdnSsMiFAY6P9hSgmV+xbTlRNLA9xllP7Q=";
+        }
+        {
+          number = "009";
+          hash = "sha256-7uMP54pLDLL+IOAQ4AMIiZz8YT4HdOuzyFV6FVLyT4w=";
+        }
+      ];
+
+  testScripts = pkgs.runCommand "bash-test-scripts" { } ''
+    mkdir -p $out/tests $out/repo-tests
+    cp ${./functional-test.sh} $out/tests/bash-functional-test.sh
+    cp ${../bzip2/roundtrip-test.sh} $out/repo-tests/bzip2-roundtrip-test.sh
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bash";
+  version = "5.3";
+  inherit src;
+
+  patches = [
+    ./wasm-anonfile.patch
+    ./wasm-callback-clone.patch
+    ./wasm-execute-callbacks.patch
+    ./wasm-fork-shim.patch
+    ./wasm-main.patch
+    ./wasm-simple-command-clone.patch
+    ./wasm-disk-command-clone.patch
+    ./wasm-process-substitution-clone.patch
+    ./wasm-coproc-clone.patch
+    ./wasm-null-command-clone.patch
+  ];
+
+  depsBuildBuild = [ pkgs.stdenv.cc ];
+
+  # GNU's release patches use -p0, while the wasm port patches use -p1.
+  prePatch = ''
+    for patch in ${toString gnuPatches}; do
+      patch -p0 < "$patch"
+    done
+  '';
+
+  buildInputs = [
+    readline
+    ncurses
+  ];
+
+  postPatch = ''
+    cp ${./bash-clone.c} bash-clone.c
+    cp ${./bash-clone.h} bash-clone.h
+    cp ${./fork-shim.c} fork-shim.c
+  '';
+
+  configureFlags = [
+    "--enable-static-link"
+    "--with-installed-readline"
+    "--without-bash-malloc"
+    "--disable-nls"
+
+    # Bash's runtime probes cannot execute target programs while cross
+    # compiling. Each answer below is established by the platform checks.
+    "bash_cv_job_control_missing=present"
+    "bash_cv_sys_named_pipes=present"
+    "bash_cv_getcwd_malloc=yes"
+    "bash_cv_getenv_redef=yes"
+    "bash_cv_func_sigsetjmp=present"
+    # Device setup links /dev/fd to the mounted procfs descriptor directory.
+    # The VM regression also proves an inherited descriptor remains usable
+    # through callback clone and exec.
+    "bash_cv_dev_fd=standard"
+    "bash_cv_pgrp_pipe=no"
+    # Target VM regressions exercise the consumers of each cache answer:
+    # lastpipe's synthetic wait status, RTMIN traps, and builtin printf %a.
+    "bash_cv_wexitstatus_offset=8"
+    "bash_cv_unusable_rtsigs=no"
+    "bash_cv_printf_a_format=yes"
+    "bash_cv_wcontinued_broken=no"
+  ];
+
+  # Bash links LOCAL_LIBS into the shell only. Preserve both paths as one
+  # configure assignment; the temporary shim remains a loud link guard until
+  # every make_child caller has a callback continuation.
+  preConfigure = ''
+    configureFlagsArray+=("LOCAL_LIBS=./bash-clone.o ./fork-shim.o")
+  '';
+
+  # Current build-platform GCC defaults to C23, where bool is a keyword.
+  # Bash's target configure probe runs in the target compiler's older mode and
+  # conditionally typedefs bool, so its build-only generators must use the
+  # matching pre-C23 language rules.
+  env.CFLAGS_FOR_BUILD = "-std=gnu17 -g";
+
+  # Bash has its own --enable-static-link switch; the generic stdenv's
+  # --disable-static flag is not a recognized Bash configure option.
+  dontDisableStatic = true;
+
+  # Bash uses sigsetjmp/siglongjmp for non-local error and signal handling.
+  # Wasm SjLj lowering must therefore cover every translation unit that can
+  # contain a call site, rather than just the final link. Bash's top-level
+  # .NOEXPORT prevents NIX_CFLAGS_COMPILE from reaching recursive make jobs,
+  # so these must be ordinary target CFLAGS.
+  env.CFLAGS = "-g -O2 -mllvm -wasm-enable-sjlj";
+
+  preBuild = ''
+    $CC $CPPFLAGS $CFLAGS -c bash-clone.c -o bash-clone.o
+    $CC $CPPFLAGS $CFLAGS -c fork-shim.c -o fork-shim.o
+  '';
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    # Readline is statically linked, but it still loads terminal descriptions
+    # at runtime. Keep the Bash filesystem fragment self-contained instead of
+    # requiring callers to add a separate ncurses slice.
+    mkdir -p "$out/share"
+    cp -r ${ncurses}/share/terminfo "$out/share/terminfo"
+  '';
+
+  passthru.checks = {
+    smoke = vm-test.vmTest {
+      name = "bash-smoke";
+      initramfs = vm-test.mkInitramfs {
+        name = "bash-smoke";
+        init = ./smoke-test.sh;
+        contents = [
+          busybox
+          finalAttrs.finalPackage
+          testScripts
+        ];
+      };
+    };
+
+    repo-script = vm-test.vmTest {
+      name = "bash-repo-script";
+      initramfs = vm-test.mkInitramfs {
+        name = "bash-repo-script";
+        init = ./repo-test-init.sh;
+        contents = [
+          busybox
+          bzip2
+          finalAttrs.finalPackage
+          testScripts
+        ];
+      };
+    };
+
+    interactive = vm-test.vmTest {
+      name = "bash-interactive";
+      initramfs = vm-test.mkInitramfs {
+        name = "bash-interactive";
+        init = ./interactive-test.sh;
+        contents = [
+          busybox
+          finalAttrs.finalPackage
+        ];
+      };
+    };
+  };
+})

--- a/distro/bash/repo-test-init.sh
+++ b/distro/bash/repo-test-init.sh
@@ -1,0 +1,17 @@
+#!/bin/busybox sh
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  printf '%s\n' "::vm-test::fail: $*"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+# This is intentionally invoked as an argument to Bash: the existing script's
+# BusyBox shebang is then only a comment, proving its portable body under Bash.
+exec bash /repo-tests/bzip2-roundtrip-test.sh

--- a/distro/bash/smoke-test.sh
+++ b/distro/bash/smoke-test.sh
@@ -1,0 +1,95 @@
+#!/bin/busybox sh
+
+fail() {
+  printf 'vm test guest failure: %s\n' "$*"
+  printf '%s\n' "::vm-test::fail: $*"
+  while :; do :; done
+}
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+
+bash --version >/tmp/bash-version 2>&1 ||
+  fail "bash --version failed: $(cat /tmp/bash-version)"
+grep -q 'GNU bash, version 5\.3' /tmp/bash-version ||
+  fail "unexpected bash version: $(head -1 /tmp/bash-version)"
+
+output=$(bash -c 'echo hi') || fail "bash -c exited nonzero"
+[ "$output" = hi ] || fail "bash -c returned [$output], expected [hi]"
+
+# Command substitution is the first make_child consumer converted to callback
+# clone. Its child receives Bash's heap state but must not mutate the parent.
+if ! bash -c 'x=1; y=$(x=2; echo inner); test "$x" = 1 && test "$y" = inner'; then
+  fail "command substitution or parent-state isolation failed"
+fi
+
+if ! bash -c 'x=outer; (x=inner; test "$x" = inner); test "$x" = outer'; then
+  fail "explicit subshell or parent-state isolation failed"
+fi
+
+if ! bash -c 'x=outer; (x=inner) & child=$!; wait "$child"; test "$x" = outer'; then
+  fail "asynchronous explicit subshell failed"
+fi
+
+output=$(bash -c 'set -o pipefail; printf "pipeline\n" | cat') ||
+  fail "builtin-to-external pipeline failed"
+[ "$output" = pipeline ] || fail "pipeline returned [$output], expected [pipeline]"
+
+if ! bash -c 'set -o pipefail; false | true; test $? -eq 1'; then
+  fail "pipeline status or pipefail failed"
+fi
+
+if ! bash -c 'x=outer; x=inner & child=$!; wait "$child"; test "$x" = outer'; then
+  fail "asynchronous simple command or isolation failed"
+fi
+
+output=$(bash -c '/bin/echo external') || fail "standalone external command failed"
+[ "$output" = external ] ||
+  fail "standalone external command returned [$output], expected [external]"
+
+if ! bash -c 'command-that-does-not-exist; status=$?; test "$status" -eq 127' \
+  >/tmp/not-found.out 2>&1; then
+  fail "missing external command did not set status 127: $(cat /tmp/not-found.out)"
+fi
+
+if ! bash -c '/bin/false; status=$?; test "$status" -eq 1'; then
+  fail "standalone failing external command lost its exit status"
+fi
+
+if ! bash -c 'value=expanded; read -r line <<EOF
+$value
+EOF
+test "$line" = expanded'; then
+  fail "expanded here-document failed"
+fi
+
+if ! bash -c 'read -r line <<<"here-string"; test "$line" = here-string'; then
+  fail "here-string failed"
+fi
+
+if ! bash -c '< /dev/null'; then
+  fail "forced-child redirection-only command failed"
+fi
+
+bash /tests/bash-functional-test.sh || fail "comprehensive Bash checks failed"
+
+# The target has no dlopen, so loadable builtins must fail explicitly.
+if bash -c 'enable -f /tmp/not-a-builtin.so example' >/tmp/loadable.out 2>&1; then
+  fail "loading a dynamic builtin unexpectedly succeeded"
+fi
+grep -q 'dynamic loading not available' /tmp/loadable.out ||
+  fail "loadable builtin failure was not explicit: $(cat /tmp/loadable.out)"
+
+if ! bash -c 'test "$(cat <(printf process-substitution))" = process-substitution'; then
+  fail "process substitution failed"
+fi
+
+if ! bash -c 'coproc child { read -r value; printf "reply:%s\n" "$value"; }; child_pid=$child_PID; printf "smoke\n" >&"${child[1]}"; read -r reply <&"${child[0]}"; wait "$child_pid" && test "$reply" = reply:smoke'; then
+  fail "coprocess bidirectional I/O or PID variable failed"
+fi
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/distro/bash/wasm-anonfile.patch
+++ b/distro/bash/wasm-anonfile.patch
@@ -1,0 +1,15 @@
+--- a/lib/sh/anonfile.c
++++ b/lib/sh/anonfile.c
+@@ -31,6 +31,12 @@
+ #endif
+ #include <filecntl.h>
+ 
++/* configure links memfd_create successfully, but generated config.h undefines
++   _GNU_SOURCE, which hides its musl prototype from <sys/mman.h>. */
++#if defined (HAVE_MEMFD_CREATE)
++extern int memfd_create (const char *, unsigned);
++#endif
++
+ #include <errno.h>
+ 
+ #include <shell.h>

--- a/distro/bash/wasm-callback-clone.patch
+++ b/distro/bash/wasm-callback-clone.patch
@@ -1,0 +1,644 @@
+--- a/jobs.h
++++ b/jobs.h
+@@ -294,7 +294,10 @@
+ extern void list_stopped_jobs (int);
+ extern void list_running_jobs (int);
+ 
+-extern pid_t make_child (char *, int);
++typedef int sh_child_func_t (void *);
++
++extern pid_t make_child (char *, int, sh_child_func_t *, void *);
++extern pid_t make_child_fork (char *, int);
+ 
+ extern int get_tty_state (void);
+ extern int set_tty_state (void);
+--- a/jobs.c
++++ b/jobs.c
+@@ -66,6 +66,7 @@
+ #include "execute_cmd.h"
+ #include "flags.h"
+ 
++#include "bash-clone.h"
+ #include "typemax.h"
+ 
+ #include "builtins/builtext.h"
+@@ -2257,12 +2258,104 @@
+   map_over_jobs (print_job, format, -1);
+ }
+ 
++/* Deliberate guard for make_child callers whose child continuation has not
++   been converted yet.  The wasm fork shim diagnoses the exact gap and traps;
++   it cannot be mistaken for a recoverable process-creation failure. */
++pid_t
++make_child_fork (char *command, int flags)
++{
++  (void)command;
++  (void)flags;
++  return fork ();
++}
++
++typedef struct
++{
++  sh_child_func_t *child_func;
++  void *child_arg;
++  int flags;
++} MAKE_CHILD_ARGS;
++
++/* Entered on bash_clone's fresh child stack.  ARGS and every continuation
++   it references are heap objects captured by clone's private memory copy. */
++static int
++make_child_callback (void *vargs)
++{
++  MAKE_CHILD_ARGS *args;
++  sh_child_func_t *child_func;
++  void *child_arg;
++  int async_p, flags;
++  pid_t mypid;
++
++  args = (MAKE_CHILD_ARGS *)vargs;
++  child_func = args->child_func;
++  child_arg = args->child_arg;
++  flags = args->flags;
++  async_p = (flags & FORK_ASYNC);
++
++  subshell_environment |= SUBSHELL_IGNTRAP;
++  mypid = getpid ();
++
++  /* Close default_buffered_input if it's > 0.  We don't close it if it's
++     0 because that's the file descriptor used when redirecting input. */
++  unset_bash_input (0);
++
++  CLRINTERRUPT;
++
++  /* Restore top-level signal mask, including unblocking SIGTERM. */
++  restore_sigmask ();
++
++  if (job_control)
++    {
++      if (pipeline_pgrp == 0)
++        pipeline_pgrp = mypid;
++
++      if (pipeline_pgrp == shell_pgrp)
++        ignore_tty_job_signals ();
++      else
++        default_tty_job_signals ();
++
++      if ((flags & FORK_NOJOB) == 0 && setpgid (mypid, pipeline_pgrp) < 0)
++        sys_error (_("child setpgid (%ld to %ld)"), (long)mypid,
++                   (long)pipeline_pgrp);
++
++      if ((flags & FORK_NOTERM) == 0 && async_p == 0 &&
++          pipeline_pgrp != shell_pgrp &&
++          ((subshell_environment & (SUBSHELL_ASYNC|SUBSHELL_PIPE)) == 0) &&
++          running_in_background == 0)
++        give_terminal_to (pipeline_pgrp, 0);
++
++#if defined (PGRP_PIPE)
++      if (pipeline_pgrp == mypid)
++        pipe_read (pgrp_pipe);
++#endif
++    }
++  else
++    {
++      if (pipeline_pgrp == 0)
++        pipeline_pgrp = shell_pgrp;
++      default_tty_job_signals ();
++    }
++
++#if defined (PGRP_PIPE)
++  sh_closepipe (pgrp_pipe);
++#endif
++
++#if defined (RECYCLES_PIDS)
++  if (last_asynchronous_pid == mypid)
++    last_asynchronous_pid = 1;
++#endif
++
++  return child_func (child_arg);
++}
++
+-/* Fork, handling errors.  Returns the pid of the newly made child, or 0.
++/* Clone a child, handling errors.  Returns its pid in the parent.
+    COMMAND is just for remembering the name of the command; we don't do
+    anything else with it.  ASYNC_P says what to do with the tty.  If
+    non-zero, then don't give it away. */
+ pid_t
+-make_child (char *command, int flags)
++make_child (char *command, int flags, sh_child_func_t *child_func,
++            void *child_arg)
+ {
+   int async_p;
+   unsigned int forksleep;
+@@ -2269,6 +2362,7 @@
+   pid_t pid;
+   PROCESS *child;
+   SigHandler *oterm;
++  MAKE_CHILD_ARGS *args;
+ 
+   sigemptyset (&oset_copy);
+   sigprocmask (SIG_BLOCK, (sigset_t *)NULL, &oset_copy);
+@@ -2294,6 +2388,11 @@
+   async_p = (flags & FORK_ASYNC);
+   forksleep = 1;
+ 
++  args = (MAKE_CHILD_ARGS *)xmalloc (sizeof (MAKE_CHILD_ARGS));
++  args->child_func = child_func;
++  args->child_arg = child_arg;
++  args->flags = flags;
++
+   /* If default_buffered_input is active, we are reading a script.  If
+      the command is asynchronous, we have already duplicated /dev/null
+      as fd 0, but have not changed the buffered stream corresponding to
+@@ -2302,7 +2401,8 @@
+     sync_buffered_stream (default_buffered_input);
+ 
+   /* Create the child, handle severe errors.  Retry on EAGAIN. */
+-  while ((pid = fork ()) < 0 && errno == EAGAIN && forksleep < FORKSLEEP_MAX)
++  while ((pid = bash_clone (make_child_callback, args)) < 0 &&
++         errno == EAGAIN && forksleep < FORKSLEEP_MAX)
+     {
+       /* bash-4.2 */
+       /* keep SIGTERM blocked until we reset the handler to SIG_IGN */
+@@ -2311,7 +2411,7 @@
+       waitchld (-1, 0);
+ 
+       errno = EAGAIN;		/* restore errno */
+-      sys_error ("fork: retry");
++      sys_error ("clone: retry");
+ 
+       if (sleep (forksleep) != 0)
+ 	break;
+@@ -2322,13 +2422,14 @@
+       sigprocmask (SIG_SETMASK, &set, (sigset_t *)NULL);
+     }
+ 
+-  if (pid != 0)
+-    if (interactive_shell)
+-      set_signal_handler (SIGTERM, oterm);
++  free (args);
++
++  if (interactive_shell)
++    set_signal_handler (SIGTERM, oterm);
+ 
+   if (pid < 0)
+     {
+-      sys_error ("fork");
++      sys_error ("clone");
+ 
+       /* Kill all of the processes in the current pipeline. */
+       terminate_current_pipeline ();
+@@ -2340,100 +2441,8 @@
+       set_exit_status (EX_NOEXEC);
+       throw_to_top_level ();	/* Reset signals, etc. */
+     }
+ 
+-  if (pid == 0)
+-    {
+-      /* In the child.  Give this child the right process group, set the
+-	 signals to the default state for a new process. */
+-      pid_t mypid;
+-
+-      subshell_environment |= SUBSHELL_IGNTRAP;
+-
+-      /* If this ends up being changed to modify or use `command' in the
+-	 child process, go back and change callers who free `command' in
+-	 the child process when this returns. */
+-      mypid = getpid ();
+-
+-      /* Close default_buffered_input if it's > 0.  We don't close it if it's
+-	 0 because that's the file descriptor used when redirecting input,
+-	 and it's wrong to close the file in that case. */
+-      unset_bash_input (0);
+-
+-      CLRINTERRUPT;	/* XXX - children have their own interrupt state */
+-
+-      /* Restore top-level signal mask, including unblocking SIGTERM */
+-      restore_sigmask ();
+-  
+-      if (job_control)
+-	{
+-	  /* All processes in this pipeline belong in the same
+-	     process group. */
+-
+-	  if (pipeline_pgrp == 0)	/* This is the first child. */
+-	    pipeline_pgrp = mypid;
+-
+-	  /* Check for running command in backquotes. */
+-	  /* XXX - do this if (flags & FORK_NOJOB)? */
+-	  if (pipeline_pgrp == shell_pgrp)
+-	    ignore_tty_job_signals ();
+-	  else
+-	    default_tty_job_signals ();
+-
+-	  /* Set the process group before trying to mess with the terminal's
+-	     process group.  This is mandated by POSIX. */
+-	  /* This is in accordance with the Posix 1003.1 standard,
+-	     section B.7.2.4, which says that trying to set the terminal
+-	     process group with tcsetpgrp() to an unused pgrp value (like
+-	     this would have for the first child) is an error.  Section
+-	     B.4.3.3, p. 237 also covers this, in the context of job control
+-	     shells. */
+-	  if ((flags & FORK_NOJOB) == 0 && setpgid (mypid, pipeline_pgrp) < 0)
+-	    sys_error (_("child setpgid (%ld to %ld)"), (long)mypid, (long)pipeline_pgrp);
+-
+-	  /* By convention (and assumption above), if
+-	     pipeline_pgrp == shell_pgrp, we are making a child for
+-	     command substitution.
+-	     In this case, we don't want to give the terminal to the
+-	     shell's process group (we could be in the middle of a
+-	     pipeline, for example). */
+-	  if ((flags & FORK_NOTERM) == 0 && async_p == 0 && pipeline_pgrp != shell_pgrp && ((subshell_environment&(SUBSHELL_ASYNC|SUBSHELL_PIPE)) == 0) && running_in_background == 0)
+-	    give_terminal_to (pipeline_pgrp, 0);
+-
+-#if defined (PGRP_PIPE)
+-	  if (pipeline_pgrp == mypid)
+-	    pipe_read (pgrp_pipe);
+-#endif
+-	}
+-      else			/* Without job control... */
+-	{
+-	  if (pipeline_pgrp == 0)
+-	    pipeline_pgrp = shell_pgrp;
+-
+-	  /* If these signals are set to SIG_DFL, we encounter the curious
+-	     situation of an interactive ^Z to a running process *working*
+-	     and stopping the process, but being unable to do anything with
+-	     that process to change its state.  On the other hand, if they
+-	     are set to SIG_IGN, jobs started from scripts do not stop when
+-	     the shell running the script gets a SIGTSTP and stops. */
+-
+-	  default_tty_job_signals ();
+-	}
+-
+-#if defined (PGRP_PIPE)
+-      /* Release the process group pipe, since our call to setpgid ()
+-	 is done.  The last call to sh_closepipe is done in stop_pipeline. */
+-      sh_closepipe (pgrp_pipe);
+-#endif /* PGRP_PIPE */
+-
+-      /* Don't set last_asynchronous_pid in the child */
+-
+-#if defined (RECYCLES_PIDS)
+-      if (last_asynchronous_pid == mypid)
+-	/* Avoid pid aliasing.  1 seems like a safe, unusual pid value. */
+-	last_asynchronous_pid = 1;
+-#endif
+-    }
+-  else
++  /* bash_clone returns only in the parent. */
+     {
+       /* In the parent.  Remember the pid of the child just created
+ 	 as the proper pgrp if this is the first child. */
+--- a/subst.c
++++ b/subst.c
+@@ -6408,6 +6408,6 @@
+ #endif /* JOB_CONTROL */
+ 
+-  pid = make_child ((char *)NULL, FORK_ASYNC|FORK_PROCSUB);
++  pid = make_child_fork ((char *)NULL, FORK_ASYNC|FORK_PROCSUB);
+   if (pid == 0)
+     {
+ #if 0
+@@ -7130,6 +7130,115 @@
+   return (ret);
+ }
+ 
++typedef struct
++{
++  char *string;
++  int read_fd;
++  int write_fd;
++  int expand_flags;
++  int parse_flags;
++} COMMAND_SUBSTITUTE_ARGS;
++
++static int
++command_substitute_child (void *vargs)
++{
++  COMMAND_SUBSTITUTE_ARGS *args;
++  int function_value, rc, result;
++
++  args = (COMMAND_SUBSTITUTE_ARGS *)vargs;
++
++  reset_signal_handlers ();
++  if (ISINTERRUPT)
++    {
++      kill (getpid (), SIGINT);
++      CLRINTERRUPT;
++    }
++  QUIT;
++  subshell_environment |= SUBSHELL_RESETTRAP;
++  subshell_environment &= ~SUBSHELL_IGNTRAP;
++
++#if defined (JOB_CONTROL)
++  set_sigchld_handler ();
++#endif
++  /* The callback bypasses command_substitute's common post-fork path.  Do
++     not let the child treat the parent's in-progress pipeline as its own. */
++  stop_making_children ();
++
++  interactive = 0;
++
++#if defined (JOB_CONTROL)
++  if (pipeline_pgrp > 0 && pipeline_pgrp != shell_pgrp)
++    shell_pgrp = pipeline_pgrp;
++#endif
++
++  set_sigint_handler ();
++  free_pushed_string_input ();
++  fpurge (stdout);
++
++  if (dup2 (args->write_fd, 1) < 0)
++    {
++      sys_error ("%s", _("command_substitute: cannot duplicate pipe as fd 1"));
++      exit (EXECUTION_FAILURE);
++    }
++
++  if ((args->write_fd != fileno (stdin)) &&
++      (args->write_fd != fileno (stdout)) &&
++      (args->write_fd != fileno (stderr)))
++    close (args->write_fd);
++  if ((args->read_fd != fileno (stdin)) &&
++      (args->read_fd != fileno (stdout)) &&
++      (args->read_fd != fileno (stderr)))
++    close (args->read_fd);
++
++  subshell_environment |= SUBSHELL_COMSUB;
++  change_flag ('v', FLAG_OFF);
++  if (inherit_errexit == 0)
++    {
++      builtin_ignoring_errexit = 0;
++      change_flag ('e', FLAG_OFF);
++    }
++  set_shellopts ();
++
++  if (expanding_redir)
++    {
++      flush_temporary_env ();
++      expanding_redir = 0;
++    }
++
++  remove_quoted_escapes (args->string);
++  if (expand_aliases && (args->expand_flags & PF_BACKQUOTE) == 0)
++    expand_aliases = posixly_correct == 0;
++
++  startup_state = 2;
++  parse_and_execute_level = 0;
++  result = setjmp_nosigs (top_level);
++
++  if (result == 0 && return_catch_flag)
++    function_value = setjmp_nosigs (return_catch);
++  else
++    function_value = 0;
++
++  if (result == ERREXIT || result == EXITPROG || result == EXITBLTIN)
++    rc = last_command_exit_value;
++  else if (result)
++    rc = EXECUTION_FAILURE;
++  else if (function_value)
++    rc = return_catch_value;
++  else
++    {
++      subshell_level++;
++      rc = parse_and_execute (args->string, "command substitution",
++                              args->parse_flags | SEVAL_NOHIST);
++    }
++
++  last_command_exit_value = rc;
++  rc = run_exit_trap ();
++#if defined (PROCESS_SUBSTITUTION)
++  unlink_fifo_list ();
++#endif
++  exit (rc);
++}
++
+ /* Perform command substitution on STRING.  This returns a WORD_DESC * with the
+    contained string possibly quoted. */
+ WORD_DESC *
+@@ -7137,8 +7246,9 @@
+ {
+   pid_t pid, old_pid, old_pipeline_pgrp, old_async_pid;
+   char *istring, *s;
+-  int result, fildes[2], function_value, pflags, rc, tflag, fork_flags;
++  int fildes[2], pflags, tflag, fork_flags;
+   WORD_DESC *ret;
++  COMMAND_SUBSTITUTE_ARGS *child_args;
+   sigset_t set, oset;
+ 
+   istring = (char *)NULL;
+@@ -7248,31 +7358,21 @@
+ 
+   old_async_pid = last_asynchronous_pid;
+   fork_flags = (subshell_environment&SUBSHELL_ASYNC) ? FORK_ASYNC : 0;
+-  pid = make_child ((char *)NULL, fork_flags|FORK_NOTERM|FORK_COMSUB);
++  child_args = (COMMAND_SUBSTITUTE_ARGS *)xmalloc (sizeof (*child_args));
++  child_args->string = string;
++  child_args->read_fd = fildes[0];
++  child_args->write_fd = fildes[1];
++  child_args->expand_flags = flags;
++  child_args->parse_flags = pflags;
++  pid = make_child ((char *)NULL, fork_flags|FORK_NOTERM|FORK_COMSUB,
++                    command_substitute_child, child_args);
++  free (child_args);
+   last_asynchronous_pid = old_async_pid;
+ 
+-  if (pid == 0)
+-    {
+-      /* Reset the signal handlers in the child, but don't free the
+-	 trap strings.  Set a flag noting that we have to free the
+-	 trap strings if we run trap to change a signal disposition. */
+-      reset_signal_handlers ();
+-      if (ISINTERRUPT)
+-	{
+-	  kill (getpid (), SIGINT);
+-	  CLRINTERRUPT;		/* if we're ignoring SIGINT somehow */
+-	}	
+-      QUIT;	/* catch any interrupts we got post-fork */
+-      subshell_environment |= SUBSHELL_RESETTRAP;
+-      subshell_environment &= ~SUBSHELL_IGNTRAP;
+-    }
+-
+ #if defined (JOB_CONTROL)
+-  /* XXX DO THIS ONLY IN PARENT ? XXX */
+   set_sigchld_handler ();
+   stop_making_children ();
+-  if (pid != 0)
+-    pipeline_pgrp = old_pipeline_pgrp;
++  pipeline_pgrp = old_pipeline_pgrp;
+ #else
+   stop_making_children ();
+ #endif /* JOB_CONTROL */
+@@ -7290,131 +7390,6 @@
+       return ((WORD_DESC *)NULL);
+     }
+ 
+-  if (pid == 0)
+-    {
+-      /* The currently executing shell is not interactive. */
+-      interactive = 0;
+-
+-#if defined (JOB_CONTROL)
+-      /* Invariant: in child processes started to run command substitutions,
+-	 pipeline_pgrp == shell_pgrp. Other parts of the shell assume this. */
+-      if (pipeline_pgrp > 0 && pipeline_pgrp != shell_pgrp)
+-	shell_pgrp = pipeline_pgrp;
+-#endif
+-
+-      set_sigint_handler ();	/* XXX */
+-
+-      free_pushed_string_input ();
+-
+-      /* Discard  buffered stdio output before replacing the underlying file
+-	 descriptor. */
+-      fpurge (stdout);
+-
+-      if (dup2 (fildes[1], 1) < 0)
+-	{
+-	  sys_error ("%s", _("command_substitute: cannot duplicate pipe as fd 1"));
+-	  exit (EXECUTION_FAILURE);
+-	}
+-
+-      /* If standard output is closed in the parent shell
+-	 (such as after `exec >&-'), file descriptor 1 will be
+-	 the lowest available file descriptor, and end up in
+-	 fildes[0].  This can happen for stdin and stderr as well,
+-	 but stdout is more important -- it will cause no output
+-	 to be generated from this command. */
+-      if ((fildes[1] != fileno (stdin)) &&
+-	  (fildes[1] != fileno (stdout)) &&
+-	  (fildes[1] != fileno (stderr)))
+-	close (fildes[1]);
+-
+-      if ((fildes[0] != fileno (stdin)) &&
+-	  (fildes[0] != fileno (stdout)) &&
+-	  (fildes[0] != fileno (stderr)))
+-	close (fildes[0]);
+-
+-#ifdef __CYGWIN__
+-      /* Let stdio know the fd may have changed from text to binary mode, and
+-	 make sure to preserve stdout line buffering. */
+-      freopen (NULL, "w", stdout);
+-      sh_setlinebuf (stdout);
+-#endif /* __CYGWIN__ */
+-
+-      /* This is a subshell environment. */
+-      subshell_environment |= SUBSHELL_COMSUB;
+-
+-      /* Many shells do not appear to inherit the -v option for command
+-	 substitutions. */
+-      change_flag ('v', FLAG_OFF);
+-
+-      /* When inherit_errexit option is not enabled, command substitution does
+-	 not inherit the -e flag.  It is enabled when Posix mode is enabled */
+-      if (inherit_errexit == 0)
+-	{
+-	  builtin_ignoring_errexit = 0;
+-	  change_flag ('e', FLAG_OFF);
+-	}
+-      set_shellopts ();
+-
+-      /* If we are expanding a redirection, we can dispose of any temporary
+-	 environment we received, since redirections are not supposed to have
+-	 access to the temporary environment.  We will have to see whether this
+-	 affects temporary environments supplied to `eval', but the temporary
+-	 environment gets copied to builtin_env at some point. */
+-      if (expanding_redir)
+-	{
+-	  flush_temporary_env ();
+-	  expanding_redir = 0;
+-	}
+-
+-      remove_quoted_escapes (string);
+-
+-      /* We want to expand aliases on this pass if we are not in posix mode
+-	 for backwards compatibility. parse_and_execute() takes care of
+-	 setting expand_aliases back to the global value when executing the
+-	 parsed string. We only do this for $(...) command substitution,
+-	 since that is what parse_comsub handles; `` comsubs are processed
+-	 using parse.y:parse_matched_pair(). */
+-      if (expand_aliases && (flags & PF_BACKQUOTE) == 0)
+-        expand_aliases = posixly_correct == 0;
+-
+-      startup_state = 2;	/* see if we can avoid a fork */
+-      parse_and_execute_level = 0;
+-
+-      /* Give command substitution a place to jump back to on failure,
+-	 so we don't go back up to main (). */
+-      result = setjmp_nosigs (top_level);
+-
+-      /* If we're running a command substitution inside a shell function,
+-	 trap `return' so we don't return from the function in the subshell
+-	 and go off to never-never land. */
+-      if (result == 0 && return_catch_flag)
+-	function_value = setjmp_nosigs (return_catch);
+-      else
+-	function_value = 0;
+-
+-      if (result == ERREXIT)
+-	rc = last_command_exit_value;
+-      else if (result == EXITPROG || result == EXITBLTIN)
+-	rc = last_command_exit_value;
+-      else if (result)
+-	rc = EXECUTION_FAILURE;
+-      else if (function_value)
+-	rc = return_catch_value;
+-      else
+-	{
+-	  subshell_level++;
+-	  rc = parse_and_execute (string, "command substitution", pflags|SEVAL_NOHIST);
+-	  /* leave subshell level intact for any exit trap */
+-	}
+-
+-      last_command_exit_value = rc;
+-      rc = run_exit_trap ();
+-#if defined (PROCESS_SUBSTITUTION)
+-      unlink_fifo_list ();
+-#endif
+-      exit (rc);
+-    }
+-  else
+     {
+       int dummyfd;
+ 
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -698,5 +698,5 @@
+       tcmd = make_command_string (command);
+       fork_flags = asynchronous ? FORK_ASYNC : 0;
+-      paren_pid = make_child (p = savestring (tcmd), fork_flags);
++      paren_pid = make_child_fork (p = savestring (tcmd), fork_flags);
+ 
+       if (user_subshell && signal_is_trapped (ERROR_TRAP) && 
+@@ -2522,7 +2522,7 @@
+   expand_aliases = expaliases_flag;
+   cmdflags = command->flags;
+ 
+-  coproc_pid = make_child (p = savestring (tcmd), FORK_ASYNC);
++  coproc_pid = make_child_fork (p = savestring (tcmd), FORK_ASYNC);
+ 
+   if (coproc_pid == 0)
+     {
+@@ -4218,6 +4218,6 @@
+       /* We have a null command, but we really want a subshell to take
+ 	 care of it.  Just fork, do piping and redirections, and exit. */
+       fork_flags = async ? FORK_ASYNC : 0;
+-      if (make_child ((char *)NULL, fork_flags) == 0)
++      if (make_child_fork ((char *)NULL, fork_flags) == 0)
+ 	{
+ 	  /* Cancel traps, in trap.c. */
+@@ -4547,5 +4547,5 @@
+       fork_flags = async ? FORK_ASYNC : 0;
+       xc = the_printed_command_except_trap;
+-      if (make_child (p = xc ? savestring (xc) : savestring (""), fork_flags) == 0)
++      if (make_child_fork (p = xc ? savestring (xc) : savestring (""), fork_flags) == 0)
+ 	{
+ 	  already_forked = 1;
+@@ -5831,7 +5831,7 @@
+   else
+     {
+       fork_flags = async ? FORK_ASYNC : 0;
+-      pid = make_child (p = savestring (command_line), fork_flags);
++      pid = make_child_fork (p = savestring (command_line), fork_flags);
+     }
+ 
+   if (pid == 0)

--- a/distro/bash/wasm-coproc-clone.patch
+++ b/distro/bash/wasm-coproc-clone.patch
@@ -1,0 +1,112 @@
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -2503,10 +2503,59 @@
+   free (namevar);
+ }
+ 
++/* The coprocess continuation cannot retain execute_coproc's parent stack;
++   bash_clone enters it on a fresh child stack using only this heap object. */
++typedef struct
++{
++  COMMAND *command;
++  struct fd_bitmap *fds_to_close;
++  char *job_command;
++  int rpipe[2];
++  int wpipe[2];
++  sigset_t old_sigmask;
++#if !MULTIPLE_COPROCS
++  int oldrfd;
++  int oldwfd;
++#endif
++} EXECUTE_COPROC_ARGS;
++
++static int
++execute_coproc_child (void *vargs)
++{
++  EXECUTE_COPROC_ARGS *args;
++  int estat;
++
++  args = (EXECUTE_COPROC_ARGS *)vargs;
++
++  close (args->rpipe[0]);
++  close (args->wpipe[1]);
++
++#if !MULTIPLE_COPROCS
++  /* execute_in_subshell cannot close these after sh_coproc was reset. */
++  if (args->oldrfd != -1)
++    close (args->oldrfd);
++  if (args->oldwfd != -1)
++    close (args->oldwfd);
++#endif
++
++#if defined (JOB_CONTROL)
++  FREE (args->job_command);
++#endif
++
++  sigprocmask (SIG_SETMASK, &args->old_sigmask, (sigset_t *)NULL);
++  estat = execute_in_subshell (args->command, 1, args->wpipe[0],
++                               args->rpipe[1], args->fds_to_close);
++
++  fflush (stdout);
++  fflush (stderr);
++  exit (estat);
++}
++
+ static int
+ execute_coproc (COMMAND *command, int pipe_in, int pipe_out, struct fd_bitmap *fds_to_close)
+ {
+-  int rpipe[2], wpipe[2], estat, invert;
++  EXECUTE_COPROC_ARGS *child_args;
++  int rpipe[2], wpipe[2], invert;
+   pid_t coproc_pid;
+   Coproc *cp;
+   char *tcmd, *p, *name;
+@@ -2552,34 +2601,23 @@
+ 
+   BLOCK_SIGNAL (SIGCHLD, set, oset);
+ 
+-  coproc_pid = make_child_fork (p = savestring (tcmd), FORK_ASYNC);
+-
+-  if (coproc_pid == 0)
+-    {
+-      close (rpipe[0]);
+-      close (wpipe[1]);
+-
++  p = savestring (tcmd);
++  child_args = (EXECUTE_COPROC_ARGS *)xmalloc (sizeof (*child_args));
++  child_args->command = command;
++  child_args->fds_to_close = fds_to_close;
++  child_args->job_command = p;
++  child_args->rpipe[0] = rpipe[0];
++  child_args->rpipe[1] = rpipe[1];
++  child_args->wpipe[0] = wpipe[0];
++  child_args->wpipe[1] = wpipe[1];
++  child_args->old_sigmask = oset;
+ #if !MULTIPLE_COPROCS
+-      /* Do this here instead of letting execute_in_subshell call
+-	 coproc_closeall since we've already overwritten sh_coproc */
+-      if (oldrfd != -1)
+-	close (oldrfd);
+-      if (oldwfd != -1)
+-	close (oldwfd);
++  child_args->oldrfd = oldrfd;
++  child_args->oldwfd = oldwfd;
+ #endif
+ 
+-#if defined (JOB_CONTROL)
+-      FREE (p);
+-#endif
+-
+-      UNBLOCK_SIGNAL (oset);
+-      estat = execute_in_subshell (command, 1, wpipe[0], rpipe[1], fds_to_close);
+-
+-      fflush (stdout);
+-      fflush (stderr);
+-
+-      exit (estat);
+-    }
++  coproc_pid = make_child (p, FORK_ASYNC, execute_coproc_child, child_args);
++  free (child_args);
+ 
+   close (rpipe[1]);
+   close (wpipe[0]);

--- a/distro/bash/wasm-disk-command-clone.patch
+++ b/distro/bash/wasm-disk-command-clone.patch
@@ -1,0 +1,306 @@
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -5833,6 +5833,124 @@
+ #  define NOTFOUND_HOOK "command_not_found_handle"
+ #endif
+ 
++typedef struct
++{
++  WORD_LIST *words;
++  REDIRECT *redirects;
++  char *command;
++  char *pathname;
++  char *job_command;
++  struct fd_bitmap *fds_to_close;
++  int pipe_in;
++  int pipe_out;
++  int async;
++  int cmdflags;
++} EXECUTE_DISK_ARGS;
++
++static int
++execute_notfound_hook (SHELL_VAR *hookf, WORD_LIST *hook_words)
++{
++  int jump;
++
++  /* The hook may call exit or otherwise throw to top_level.  Translate the
++     jump into the status this child callback will report instead of using
++     the inherited recovery buffer on the parent's abandoned stack. */
++  jump = setjmp_nosigs (top_level);
++  if (jump == EXITPROG || jump == EXITBLTIN || jump == ERREXIT)
++    return last_command_exit_value;
++  else if (jump)
++    return last_command_exit_value == EXECUTION_SUCCESS
++           ? EXECUTION_FAILURE : last_command_exit_value;
++
++  return execute_shell_function (hookf, hook_words);
++}
++
++static int
++execute_disk_command_child (void *vargs)
++{
++  EXECUTE_DISK_ARGS *args;
++  char **exec_args;
++  int old_interactive, restart;
++  SHELL_VAR *hookf;
++  WORD_LIST *hook_words;
++
++  args = (EXECUTE_DISK_ARGS *)vargs;
++
++  reset_terminating_signals ();
++  restore_original_signals ();
++  subshell_environment &= ~SUBSHELL_IGNTRAP;
++
++#if defined (JOB_CONTROL)
++  FREE (args->job_command);
++#endif
++
++  if (args->async)
++    {
++      if ((args->cmdflags & CMD_STDIN_REDIR) &&
++          args->pipe_in == NO_PIPE &&
++          stdin_redirects (args->redirects) == 0)
++        async_redirect_stdin ();
++      setup_async_signals ();
++    }
++
++  if (args->fds_to_close)
++    close_fd_bitmap (args->fds_to_close);
++  do_piping (args->pipe_in, args->pipe_out);
++
++  old_interactive = interactive;
++  if (args->async)
++    interactive = 0;
++  subshell_environment |= SUBSHELL_FORK;
++
++#if defined (PROCESS_SUBSTITUTION) && !defined (HAVE_DEV_FD)
++  clear_fifo_list ();
++#endif
++
++  if (args->redirects && do_redirections (args->redirects, RX_ACTIVE) != 0)
++    {
++#if defined (PROCESS_SUBSTITUTION)
++      unlink_all_fifos ();
++#endif
++      exit (EXECUTION_FAILURE);
++    }
++
++#if defined (PROCESS_SUBSTITUTION) && !defined (HAVE_DEV_FD)
++  unlink_all_fifos ();
++#endif
++
++  if (args->async)
++    interactive = old_interactive;
++
++  if (args->command == 0)
++    {
++      hookf = find_function (NOTFOUND_HOOK);
++      if (hookf == 0)
++        {
++          args->pathname = printable_filename (args->pathname, 0);
++          internal_error ("%s: %s", args->pathname, notfound_str);
++          exit (EX_NOTFOUND);
++        }
++
++      without_job_control ();
++#if defined (JOB_CONTROL)
++      set_sigchld_handler ();
++#endif
++      hook_words = make_word_list (make_word (NOTFOUND_HOOK), args->words);
++      exit (execute_notfound_hook (hookf, hook_words));
++    }
++
++  exec_args = strvec_from_word_list (args->words, 0, 0, (int *)NULL);
++
++  /* ENOEXEC makes shell_execve prepare a new Bash invocation and jump to
++     subshell_top_level.  Recreate that continuation on this clone stack;
++     the one installed by the original main() belongs to the parent stack. */
++  restart = setjmp_sigs (subshell_top_level);
++  if (restart)
++    restart_shell_from_clone ();
++
++  exit (shell_execve (args->command, exec_args, export_env));
++}
++
+ static int
+ execute_disk_command (WORD_LIST *words, REDIRECT *redirects, char *command_line,
+ 		      int pipe_in, int pipe_out, int async,
+@@ -5839,10 +5957,8 @@
+ 		      struct fd_bitmap *fds_to_close, int cmdflags)
+ {
+-  char *pathname, *command, **args, *p;
++  char *pathname, *command, *p;
+   int nofork, stdpath, result, fork_flags;
+-  pid_t pid;
+-  SHELL_VAR *hookf;
+-  WORD_LIST *wl;
++  EXECUTE_DISK_ARGS *child_args;
+ 
+   stdpath = (cmdflags & CMD_STDPATH);	/* use command -p path */
+   nofork = (cmdflags & CMD_NO_FORK);	/* Don't fork, just exec, if no pipes */
+@@ -5892,111 +6008,30 @@
+      of COMMAND, since we want the error messages to be redirected. */
+   /* If we can get away without forking and there are no pipes to deal with,
+      don't bother to fork, just directly exec the command. */
+-  if (nofork && pipe_in == NO_PIPE && pipe_out == NO_PIPE)
+-    pid = 0;
+-  else
+-    {
+-      fork_flags = async ? FORK_ASYNC : 0;
+-      pid = make_child_fork (p = savestring (command_line), fork_flags);
+-    }
+-
+-  if (pid == 0)
+-    {
+-      int old_interactive;
+-
+-      reset_terminating_signals ();	/* XXX */
+-      /* Cancel traps, in trap.c. */
+-      restore_original_signals ();
+-      subshell_environment &= ~SUBSHELL_IGNTRAP;
+-
+-#if defined (JOB_CONTROL)
+-      FREE (p);
+-#endif
+-
+-      /* restore_original_signals may have undone the work done
+-	 by make_child to ensure that SIGINT and SIGQUIT are ignored
+-	 in asynchronous children. */
+-      if (async)
+-	{
+-	  if ((cmdflags & CMD_STDIN_REDIR) &&
+-		pipe_in == NO_PIPE &&
+-		(stdin_redirects (redirects) == 0))
+-	    async_redirect_stdin ();
+-	  setup_async_signals ();
+-	}
+-
+-      /* This functionality is now provided by close-on-exec of the
+-	 file descriptors manipulated by redirection and piping.
+-	 Some file descriptors still need to be closed in all children
+-	 because of the way bash does pipes; fds_to_close is a
+-	 bitmap of all such file descriptors. */
+-      if (fds_to_close)
+-	close_fd_bitmap (fds_to_close);
+-
+-      do_piping (pipe_in, pipe_out);
+-
+-      old_interactive = interactive;
+-      if (async)
+-	interactive = 0;
+-
+-      subshell_environment |= SUBSHELL_FORK;	/* XXX - was just = */
+-
+-#if defined (PROCESS_SUBSTITUTION) && !defined (HAVE_DEV_FD)
+-      clear_fifo_list ();	/* XXX - we haven't created any FIFOs */
+-#endif
+-
+-      /* reset shell_pgrp to pipeline_pgrp here for word expansions performed
+-         by the redirections here? */
+-      if (redirects && (do_redirections (redirects, RX_ACTIVE) != 0))
+-	{
+-#if defined (PROCESS_SUBSTITUTION)
+-	  /* Try to remove named pipes that may have been created as the
+-	     result of redirections. */
+-	  unlink_all_fifos ();
+-#endif /* PROCESS_SUBSTITUTION */
+-	  exit (EXECUTION_FAILURE);
+-	}
+-
+-#if defined (PROCESS_SUBSTITUTION) && !defined (HAVE_DEV_FD)
+-      /* This should only contain FIFOs created as part of redirection
+-	 expansion. */
+-      unlink_all_fifos ();
+-#endif
+-
+-      if (async)
+-	interactive = old_interactive;
+-
+-      if (command == 0)
+-	{
+-	  hookf = find_function (NOTFOUND_HOOK);
+-	  if (hookf == 0)
+-	    {
+-	      /* Make sure filenames are displayed using printable characters */
+-	      pathname = printable_filename (pathname, 0);
+-	      internal_error ("%s: %s", pathname, notfound_str);
+-	      exit (EX_NOTFOUND);	/* Posix.2 says the exit status is 127 */
+-	    }
+-
+-	  /* We don't want to manage process groups for processes we start
+-	     from here, so we turn off job control and don't attempt to
+-	     manipulate the terminal's process group. */
+-	  without_job_control ();
+-
+-#if defined (JOB_CONTROL)
+-	  set_sigchld_handler ();
+-#endif
+-
+-	  wl = make_word_list (make_word (NOTFOUND_HOOK), words);
+-	  exit (execute_shell_function (hookf, wl));
+-	}
+-
+-      /* Execve expects the command name to be in args[0].  So we
+-	 leave it there, in the same format that the user used to
+-	 type it in. */
+-      args = strvec_from_word_list (words, 0, 0, (int *)NULL);
+-      exit (shell_execve (command, args, export_env));
+-    }
++  p = (char *)NULL;
++  child_args = (EXECUTE_DISK_ARGS *)xmalloc (sizeof (*child_args));
++  child_args->words = words;
++  child_args->redirects = redirects;
++  child_args->command = command;
++  child_args->pathname = pathname;
++  child_args->fds_to_close = fds_to_close;
++  child_args->pipe_in = pipe_in;
++  child_args->pipe_out = pipe_out;
++  child_args->async = async;
++  child_args->cmdflags = cmdflags;
++
++  if (nofork && pipe_in == NO_PIPE && pipe_out == NO_PIPE)
++    {
++      child_args->job_command = (char *)NULL;
++      return (execute_disk_command_child (child_args));
++    }
+   else
+     {
++      p = savestring (command_line);
++      child_args->job_command = p;
++      fork_flags = async ? FORK_ASYNC : 0;
++      make_child (p, fork_flags, execute_disk_command_child, child_args);
++      free (child_args);
++
+ parent_return:
+       QUIT;
+--- a/shell.h
++++ b/shell.h
+@@ -126,5 +126,7 @@
+ extern char **subshell_envp;
+ 
++extern void restart_shell_from_clone (void) __attribute__((__noreturn__));
++
+ /* variables managed using shopt */
+ extern int hup_on_exit;
+ extern int check_jobs_at_exit;
+--- a/shell.c
++++ b/shell.c
+@@ -835,6 +835,18 @@
+   exit_shell (last_command_exit_value);
+ }
+ 
++/* Continue shell_execve's ENOEXEC restart from a callback clone.  Calling
++   main here is bounded by the process boundary: any later disk command that
++   needs a child receives another fresh callback stack. */
++void
++restart_shell_from_clone (void)
++{
++  environ = subshell_envp;
++  sourced_env = 0;
++  main (subshell_argc, subshell_argv);
++  sh_exit (EXECUTION_FAILURE);
++}
++
+ static int
+ parse_long_options (char **argv, int arg_start, int arg_end)
+ {

--- a/distro/bash/wasm-execute-callbacks.patch
+++ b/distro/bash/wasm-execute-callbacks.patch
@@ -1,0 +1,110 @@
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -608,6 +608,49 @@
+ 
+ #define DESCRIBE_PID(pid) do { if (interactive) describe_pid (pid); } while (0)
+ 
++typedef struct
++{
++  COMMAND *command;
++  struct fd_bitmap *fds_to_close;
++  char *job_command;
++  int asynchronous;
++  int pipe_in;
++  int pipe_out;
++  int user_subshell;
++} EXECUTE_SUBSHELL_ARGS;
++
++static int
++execute_subshell_child (void *vargs)
++{
++  EXECUTE_SUBSHELL_ARGS *args;
++  int run_exit_trap;
++
++  args = (EXECUTE_SUBSHELL_ARGS *)vargs;
++
++#if defined (JOB_CONTROL)
++  FREE (args->job_command);
++#endif
++
++  /* Forced group subshells need the exit trap here; explicit () subshells
++     arrange it inside execute_in_subshell. */
++  run_exit_trap = args->user_subshell == 0 &&
++                  args->command->type == cm_group &&
++                  args->pipe_in == NO_PIPE && args->pipe_out == NO_PIPE &&
++                  args->asynchronous;
++  run_exit_trap += args->user_subshell == 0 &&
++                   args->command->type == cm_group &&
++                   (args->pipe_in != NO_PIPE || args->pipe_out != NO_PIPE) &&
++                   args->asynchronous == 0;
++
++  last_command_exit_value = execute_in_subshell (
++      args->command, args->asynchronous, args->pipe_in, args->pipe_out,
++      args->fds_to_close);
++  if (run_exit_trap)
++    subshell_exit (last_command_exit_value);
++  else
++    sh_exit (last_command_exit_value);
++}
++
+ /* Execute the command passed in COMMAND, perhaps doing it asynchronously.
+    COMMAND is exactly what read_command () places into GLOBAL_COMMAND.
+    ASYNCHRONOUS, if non-zero, says to do this command in the background.
+@@ -687,7 +730,7 @@
+     {
+       pid_t paren_pid;
+-      int s;
+       char *p;
++      EXECUTE_SUBSHELL_ARGS *child_args;
+ 
+       /* Fork a subshell, turn off the subshell bit, turn off job
+ 	 control and call execute_command () on the command again. */
+@@ -698,7 +741,17 @@
+ 	/* Otherwise we defer setting line_number */
+       tcmd = make_command_string (command);
+       fork_flags = asynchronous ? FORK_ASYNC : 0;
+-      paren_pid = make_child_fork (p = savestring (tcmd), fork_flags);
++      p = savestring (tcmd);
++      child_args = (EXECUTE_SUBSHELL_ARGS *)xmalloc (sizeof (*child_args));
++      child_args->command = command;
++      child_args->fds_to_close = fds_to_close;
++      child_args->job_command = p;
++      child_args->asynchronous = asynchronous;
++      child_args->pipe_in = pipe_in;
++      child_args->pipe_out = pipe_out;
++      child_args->user_subshell = user_subshell;
++      paren_pid = make_child (p, fork_flags, execute_subshell_child, child_args);
++      free (child_args);
+ 
+       if (user_subshell && signal_is_trapped (ERROR_TRAP) && 
+ 	  signal_in_progress (DEBUG_TRAP) == 0 && running_trap == 0)
+@@ -707,29 +760,6 @@
+ 	  the_printed_command_except_trap = savestring (the_printed_command);
+ 	}
+ 
+-      if (paren_pid == 0)
+-        {
+-#if defined (JOB_CONTROL)
+-	  FREE (p);		/* child doesn't use pointer */
+-#endif
+-	  /* We want to run the exit trap for forced {} subshells, and we
+-	     want to note this before execute_in_subshell modifies the
+-	     COMMAND struct.  Need to keep in mind that execute_in_subshell
+-	     runs the exit trap for () subshells itself. */
+-	  /* This handles { command; } & */
+-	  s = user_subshell == 0 && command->type == cm_group && pipe_in == NO_PIPE && pipe_out == NO_PIPE && asynchronous;
+-	  /* run exit trap for : | { ...; } and { ...; } | : */
+-	  /* run exit trap for : | ( ...; ) and ( ...; ) | : */
+-	  s += user_subshell == 0 && command->type == cm_group && (pipe_in != NO_PIPE || pipe_out != NO_PIPE) && asynchronous == 0;
+-
+-	  last_command_exit_value = execute_in_subshell (command, asynchronous, pipe_in, pipe_out, fds_to_close);
+-	  if (s)
+-	    subshell_exit (last_command_exit_value);
+-	  else
+-	    sh_exit (last_command_exit_value);
+-	  /* NOTREACHED */
+-        }
+-      else
+ 	{
+ 	  close_pipes (pipe_in, pipe_out);
+ 

--- a/distro/bash/wasm-fork-shim.patch
+++ b/distro/bash/wasm-fork-shim.patch
@@ -1,0 +1,12 @@
+--- a/jobs.h
++++ b/jobs.h
+@@ -221,7 +221,9 @@
+ #define FORK_PROCSUB	0x10		/* process substitution */
+
+ /* System calls. */
+-#if !defined (HAVE_UNISTD_H)
++/* wasm musl deliberately omits fork; declare the temporary fatal link shim
++   until all make_child continuations use callback clone. */
++#if !defined (HAVE_UNISTD_H) || defined (__wasm__)
+ extern pid_t fork (void), getpid (void), getpgrp (void);
+ #endif /* !HAVE_UNISTD_H */

--- a/distro/bash/wasm-main.patch
+++ b/distro/bash/wasm-main.patch
@@ -1,0 +1,28 @@
+--- a/shell.c
++++ b/shell.c
+@@ -104,1 +104,1 @@
+-#if defined (NO_MAIN_ENV_ARG)
++#if defined (NO_MAIN_ENV_ARG) || defined (__wasm__)
+@@ -365,7 +365,7 @@
+ }
+ #endif /* __CYGWIN__ */
+ 
+-#if defined (NO_MAIN_ENV_ARG)
++#if defined (NO_MAIN_ENV_ARG) || defined (__wasm__)
+ /* systems without third argument to main() */
+ int
+ main (int argc, char **argv)
+@@ -381,11 +381,11 @@
+ #endif
+   volatile int locally_skip_execution;
+   volatile int arg_index, top_level_arg_index;
+-#if defined (__OPENNT) || defined (__MVS__)
++#if defined (__OPENNT) || defined (__MVS__) || defined (__wasm__)
+   char **env;
+ 
+   env = environ;
+-#endif /* __OPENNT || __MVS__ */
++#endif /* __OPENNT || __MVS__ || __wasm__ */
+ 
+   USE_VAR(argc);
+   USE_VAR(argv);

--- a/distro/bash/wasm-null-command-clone.patch
+++ b/distro/bash/wasm-null-command-clone.patch
@@ -1,0 +1,116 @@
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -4264,13 +4264,56 @@
+     VUNSETATTR (var, att_exported);
+ }
+ 
++/* Forced null-command children also enter on a fresh clone stack. */
++typedef struct
++{
++  REDIRECT *redirects;
++  int pipe_in;
++  int pipe_out;
++  int async;
++} EXECUTE_NULL_COMMAND_ARGS;
++
++static int
++execute_null_command_child (void *vargs)
++{
++  EXECUTE_NULL_COMMAND_ARGS *args;
++  int code;
++
++  args = (EXECUTE_NULL_COMMAND_ARGS *)vargs;
++
++  restore_original_signals ();
++  do_piping (args->pipe_in, args->pipe_out);
++
++#if defined (COPROCESS_SUPPORT)
++  coproc_closeall ();
++#endif
++
++  interactive = 0;
++
++  subshell_environment = 0;
++  if (args->async)
++    subshell_environment |= SUBSHELL_ASYNC;
++  if (args->pipe_in != NO_PIPE || args->pipe_out != NO_PIPE)
++    subshell_environment |= SUBSHELL_PIPE;
++
++  code = setjmp_nosigs (top_level);
++  if (code)
++    exit (EXECUTION_FAILURE);
++
++  if (do_redirections (args->redirects, RX_ACTIVE) == 0)
++    exit (EXECUTION_SUCCESS);
++  else
++    exit (EXECUTION_FAILURE);
++}
++
+ /* Execute a null command.  Fork a subshell if the command uses pipes or is
+    to be run asynchronously.  This handles all the side effects that are
+    supposed to take place. */
+ static int
+ execute_null_command (REDIRECT *redirects, int pipe_in, int pipe_out, int async)
+ {
+-  int r, code;
++  EXECUTE_NULL_COMMAND_ARGS *child_args;
++  int r;
+   int forcefork, fork_flags;
+   REDIRECT *rd;
+ 
+@@ -4286,43 +4329,21 @@
+       /* We have a null command, but we really want a subshell to take
+ 	 care of it.  Just fork, do piping and redirections, and exit. */
+       fork_flags = async ? FORK_ASYNC : 0;
+-      if (make_child_fork ((char *)NULL, fork_flags) == 0)
+-	{
+-	  /* Cancel traps, in trap.c. */
+-	  restore_original_signals ();		/* XXX */
+-
+-	  do_piping (pipe_in, pipe_out);
+-
+-#if defined (COPROCESS_SUPPORT)
+-	  coproc_closeall ();
+-#endif
+-
+-	  interactive = 0;			/* XXX */
++      child_args = (EXECUTE_NULL_COMMAND_ARGS *)xmalloc (sizeof (*child_args));
++      child_args->redirects = redirects;
++      child_args->pipe_in = pipe_in;
++      child_args->pipe_out = pipe_out;
++      child_args->async = async;
++      make_child ((char *)NULL, fork_flags, execute_null_command_child,
++		  child_args);
++      free (child_args);
+ 
+-	  subshell_environment = 0;
+-	  if (async)
+-	    subshell_environment |= SUBSHELL_ASYNC;
+-	  if (pipe_in != NO_PIPE || pipe_out != NO_PIPE)
+-	    subshell_environment |= SUBSHELL_PIPE;
+-
+-	  code = setjmp_nosigs (top_level);
+-	  if (code)
+-	    exit (EXECUTION_FAILURE);
+-
+-	  if (do_redirections (redirects, RX_ACTIVE) == 0)
+-	    exit (EXECUTION_SUCCESS);
+-	  else
+-	    exit (EXECUTION_FAILURE);
+-	}
+-      else
+-	{
+-	  close_pipes (pipe_in, pipe_out);
++      close_pipes (pipe_in, pipe_out);
+ #if defined (PROCESS_SUBSTITUTION) && defined (HAVE_DEV_FD)
+-	  if (pipe_out == NO_PIPE)
+-	    unlink_fifo_list ();
++      if (pipe_out == NO_PIPE)
++	unlink_fifo_list ();
+ #endif
+-	  return (EXECUTION_SUCCESS);
+-	}
++      return (EXECUTION_SUCCESS);
+     }
+   else
+     {

--- a/distro/bash/wasm-process-substitution-clone.patch
+++ b/distro/bash/wasm-process-substitution-clone.patch
@@ -1,0 +1,388 @@
+--- a/subst.c
++++ b/subst.c
+@@ -6344,6 +6344,143 @@
+ 
+ #endif /* HAVE_DEV_FD */
+ 
++/* bash_clone starts this continuation on a fresh stack, so every value from
++   process_substitute must arrive through this heap object. */
++typedef struct
++{
++  char *string;
++  char *pathname;
++  int open_for_read_in_child;
++#if defined (HAVE_DEV_FD)
++  int parent_pipe_fd;
++  int child_pipe_fd;
++#endif
++#if defined (JOB_CONTROL)
++  pid_t old_pipeline_pgrp;
++#endif
++} PROCESS_SUBSTITUTE_ARGS;
++
++static int
++process_substitute_child (void *vargs)
++{
++  PROCESS_SUBSTITUTE_ARGS *args;
++  int fd, function_value, rc, result;
++
++  args = (PROCESS_SUBSTITUTE_ARGS *)vargs;
++
++  interactive = 0;
++
++  reset_terminating_signals ();
++  free_pushed_string_input ();
++  restore_original_signals ();
++  subshell_environment &= ~SUBSHELL_IGNTRAP;
++  QUIT;
++  setup_async_signals ();
++
++  subshell_environment |= SUBSHELL_COMSUB|SUBSHELL_PROCSUB|SUBSHELL_ASYNC;
++  change_flag ('v', FLAG_OFF);
++
++  if (expanding_redir)
++    flush_temporary_env ();
++
++#if defined (JOB_CONTROL)
++  set_sigchld_handler ();
++  stop_making_children ();
++  pipeline_pgrp = args->old_pipeline_pgrp;
++#else
++  stop_making_children ();
++#endif
++
++  set_sigint_handler ();
++
++#if defined (JOB_CONTROL)
++  set_job_control (0);
++  procsub_clear ();
++
++  if (pipeline_pgrp != shell_pgrp)
++    pipeline_pgrp = getpid ();
++#endif
++
++#if !defined (HAVE_DEV_FD)
++  fd = open (args->pathname,
++             args->open_for_read_in_child ? O_RDONLY : O_WRONLY);
++  if (fd < 0)
++    {
++      if (args->open_for_read_in_child)
++	sys_error (_("cannot open named pipe %s for reading"), args->pathname);
++      else
++	sys_error (_("cannot open named pipe %s for writing"), args->pathname);
++      exit (127);
++    }
++  if (args->open_for_read_in_child && sh_unset_nodelay_mode (fd) < 0)
++    {
++      sys_error (_("cannot reset nodelay mode for fd %d"), fd);
++      exit (127);
++    }
++#else
++  fd = args->child_pipe_fd;
++#endif
++
++  if (args->open_for_read_in_child == 0)
++    fpurge (stdout);
++
++  if (dup2 (fd, args->open_for_read_in_child ? 0 : 1) < 0)
++    {
++      sys_error (_("cannot duplicate named pipe %s as fd %d"), args->pathname,
++	args->open_for_read_in_child ? 0 : 1);
++      exit (127);
++    }
++
++  if (fd != (args->open_for_read_in_child ? 0 : 1))
++    close (fd);
++
++  if (current_fds_to_close)
++    {
++      close_fd_bitmap (current_fds_to_close);
++      current_fds_to_close = (struct fd_bitmap *)NULL;
++    }
++
++#if defined (HAVE_DEV_FD)
++  close (args->parent_pipe_fd);
++  dev_fd_list[args->parent_pipe_fd] = 0;
++#endif
++
++  expanding_redir = 0;
++  remove_quoted_escapes (args->string);
++
++  startup_state = 2;
++  parse_and_execute_level = 0;
++
++  result = setjmp_nosigs (top_level);
++  if (result == 0 && return_catch_flag)
++    function_value = setjmp_nosigs (return_catch);
++  else
++    function_value = 0;
++
++  if (result == ERREXIT)
++    rc = last_command_exit_value;
++  else if (result == EXITPROG || result == EXITBLTIN)
++    rc = last_command_exit_value;
++  else if (result)
++    rc = EXECUTION_FAILURE;
++  else if (function_value)
++    rc = return_catch_value;
++  else
++    {
++      subshell_level++;
++      rc = parse_and_execute (args->string, "process substitution",
++			      (SEVAL_NONINT|SEVAL_NOHIST));
++    }
++
++#if !defined (HAVE_DEV_FD)
++  close (args->open_for_read_in_child ? 0 : 1);
++#endif
++
++  last_command_exit_value = rc;
++  rc = run_exit_trap ();
++  exit (rc);
++}
++
+ /* Return a filename that will open a connection to the process defined by
+    executing STRING.  HAVE_DEV_FD, if defined, means open a pipe and return
+    a filename in /dev/fd corresponding to a descriptor that is one of the
+@@ -6360,7 +6497,7 @@
+ process_substitute (char *string, int open_for_read_in_child)
+ {
+   char *pathname;
+-  int fd, result, rc, function_value;
++  PROCESS_SUBSTITUTE_ARGS *child_args;
+   pid_t old_pid, pid;
+ #if defined (HAVE_DEV_FD)
+   int parent_pipe_fd, child_pipe_fd;
+@@ -6407,41 +6544,21 @@
+   save_pipeline (1);
+ #endif /* JOB_CONTROL */
+ 
+-  pid = make_child_fork ((char *)NULL, FORK_ASYNC|FORK_PROCSUB);
+-  if (pid == 0)
+-    {
+-#if 0
+-      int old_interactive;
+-
+-      old_interactive = interactive;
++  child_args = (PROCESS_SUBSTITUTE_ARGS *)xmalloc (sizeof (*child_args));
++  child_args->string = string;
++  child_args->pathname = pathname;
++  child_args->open_for_read_in_child = open_for_read_in_child;
++#if defined (HAVE_DEV_FD)
++  child_args->parent_pipe_fd = parent_pipe_fd;
++  child_args->child_pipe_fd = child_pipe_fd;
++#endif
++#if defined (JOB_CONTROL)
++  child_args->old_pipeline_pgrp = old_pipeline_pgrp;
+ #endif
+-      /* The currently-executing shell is not interactive */
+-      interactive = 0;
+ 
+-      reset_terminating_signals ();	/* XXX */
+-      free_pushed_string_input ();
+-      /* Cancel traps, in trap.c. */
+-      restore_original_signals ();	/* XXX - what about special builtins? bash-4.2 */
+-      subshell_environment &= ~SUBSHELL_IGNTRAP;
+-      QUIT;	/* catch any interrupts we got post-fork */
+-      setup_async_signals ();
+-#if 0
+-      if (open_for_read_in_child == 0 && old_interactive && (bash_input.type == st_stdin || bash_input.type == st_stream))
+-	async_redirect_stdin ();
+-#endif
+-
+-      subshell_environment |= SUBSHELL_COMSUB|SUBSHELL_PROCSUB|SUBSHELL_ASYNC;
+-
+-      /* We don't inherit the verbose option for command substitutions now, so
+-	 let's try it for process substitutions. */
+-      change_flag ('v', FLAG_OFF);
+-
+-      /* if we're expanding a redirection, we shouldn't have access to the
+-	 temporary environment, but commands in the subshell should have
+-	 access to their own temporary environment. */
+-      if (expanding_redir)
+-        flush_temporary_env ();
+-    }
++  pid = make_child ((char *)NULL, FORK_ASYNC|FORK_PROCSUB,
++		    process_substitute_child, child_args);
++  free (child_args);
+ 
+ #if defined (JOB_CONTROL)
+   set_sigchld_handler ();
+@@ -6466,166 +6583,32 @@
+       return ((char *)NULL);
+     }
+ 
+-  if (pid > 0)
+-    {
+ #if defined (JOB_CONTROL)
+-      last_procsub_child = restore_pipeline (0);
+-      /* We assume that last_procsub_child->next == last_procsub_child because
+-	 of how jobs.c:add_process() works. */
+-      last_procsub_child->next = 0;
+-      last_procsub_pid = last_procsub_child->pid;
+-      procsub_add (last_procsub_child);
++  last_procsub_child = restore_pipeline (0);
++  /* We assume that last_procsub_child->next == last_procsub_child because
++     of how jobs.c:add_process() works. */
++  last_procsub_child->next = 0;
++  last_procsub_pid = last_procsub_child->pid;
++  procsub_add (last_procsub_child);
+ #endif
+ 
+ #if defined (HAVE_DEV_FD)
+-      dev_fd_list[parent_pipe_fd] = pid;
++  dev_fd_list[parent_pipe_fd] = pid;
+ #else
+-      fifo_list[nfifo-1].proc = pid;
++  fifo_list[nfifo-1].proc = pid;
+ #endif
+ 
+-      last_made_pid = old_pid;
++  last_made_pid = old_pid;
+ 
+ #if defined (JOB_CONTROL) && defined (PGRP_PIPE)
+-      close_pgrp_pipe ();
++  close_pgrp_pipe ();
+ #endif /* JOB_CONTROL && PGRP_PIPE */
+ 
+ #if defined (HAVE_DEV_FD)
+-      close (child_pipe_fd);
+-#endif /* HAVE_DEV_FD */
+-
+-      return (pathname);
+-    }
+-
+-  set_sigint_handler ();
+-
+-#if defined (JOB_CONTROL)
+-  /* make sure we don't have any job control */
+-  set_job_control (0);
+-
+-  /* Clear out any existing list of process substitutions */
+-  procsub_clear ();
+-
+-  /* The idea is that we want all the jobs we start from an async process
+-     substitution to be in the same process group, but not the same pgrp
+-     as our parent shell, since we don't want to affect our parent shell's
+-     jobs if we get a SIGHUP and end up calling hangup_all_jobs, for example.
+-     If pipeline_pgrp != shell_pgrp, we assume that there is a job control
+-     shell somewhere in our parent process chain (since make_child initializes
+-     pipeline_pgrp to shell_pgrp if job_control == 0). What we do in this
+-     case is to set pipeline_pgrp to our PID, so all jobs started by this
+-     process have that same pgrp and we are basically the process group leader.
+-     This should not have negative effects on child processes surviving
+-     after we exit, since we wait for the children we create, but that is
+-     something to watch for. */
+-
+-  if (pipeline_pgrp != shell_pgrp)
+-    pipeline_pgrp = getpid ();
+-#endif /* JOB_CONTROL */
+-
+-#if !defined (HAVE_DEV_FD)
+-  /* Open the named pipe in the child. */
+-  fd = open (pathname, open_for_read_in_child ? O_RDONLY : O_WRONLY);
+-  if (fd < 0)
+-    {
+-      /* Two separate strings for ease of translation. */
+-      if (open_for_read_in_child)
+-	sys_error (_("cannot open named pipe %s for reading"), pathname);
+-      else
+-	sys_error (_("cannot open named pipe %s for writing"), pathname);
+-
+-      exit (127);
+-    }
+-  if (open_for_read_in_child)
+-    {
+-      if (sh_unset_nodelay_mode (fd) < 0)
+-	{
+-	  sys_error (_("cannot reset nodelay mode for fd %d"), fd);
+-	  exit (127);
+-	}
+-    }
+-#else /* HAVE_DEV_FD */
+-  fd = child_pipe_fd;
+-#endif /* HAVE_DEV_FD */
+-
+-  /* Discard  buffered stdio output before replacing the underlying file
+-     descriptor. */
+-  if (open_for_read_in_child == 0)
+-    fpurge (stdout);
+-
+-  if (dup2 (fd, open_for_read_in_child ? 0 : 1) < 0)
+-    {
+-      sys_error (_("cannot duplicate named pipe %s as fd %d"), pathname,
+-	open_for_read_in_child ? 0 : 1);
+-      exit (127);
+-    }
+-
+-  if (fd != (open_for_read_in_child ? 0 : 1))
+-    close (fd);
+-
+-  /* Need to close any files that this process has open to pipes inherited
+-     from its parent. */
+-  if (current_fds_to_close)
+-    {
+-      close_fd_bitmap (current_fds_to_close);
+-      current_fds_to_close = (struct fd_bitmap *)NULL;
+-    }
+-
+-#if defined (HAVE_DEV_FD)
+-  /* Make sure we close the parent's end of the pipe and clear the slot
+-     in the fd list so it is not closed later, if reallocated by, for
+-     instance, pipe(2). */
+-  close (parent_pipe_fd);
+-  dev_fd_list[parent_pipe_fd] = 0;
++  close (child_pipe_fd);
+ #endif /* HAVE_DEV_FD */
+ 
+-  /* subshells shouldn't have this flag, which controls using the temporary
+-     environment for variable lookups.  We have already flushed the temporary
+-     environment above in the case we're expanding a redirection, so processes
+-     executed by this command need to be able to set it independently of their
+-     parent. */
+-  expanding_redir = 0;
+-
+-  remove_quoted_escapes (string);
+-
+-  startup_state = 2;	/* see if we can avoid a fork */
+-  parse_and_execute_level = 0;
+-
+-  /* Give process substitution a place to jump back to on failure,
+-     so we don't go back up to main (). */
+-  result = setjmp_nosigs (top_level);
+-
+-  /* If we're running a process substitution inside a shell function,
+-     trap `return' so we don't return from the function in the subshell
+-     and go off to never-never land. */
+-  if (result == 0 && return_catch_flag)
+-    function_value = setjmp_nosigs (return_catch);
+-  else
+-    function_value = 0;
+-
+-  if (result == ERREXIT)
+-    rc = last_command_exit_value;
+-  else if (result == EXITPROG || result == EXITBLTIN)
+-    rc = last_command_exit_value;
+-  else if (result)
+-    rc = EXECUTION_FAILURE;
+-  else if (function_value)
+-    rc = return_catch_value;
+-  else
+-    {
+-      subshell_level++;
+-      rc = parse_and_execute (string, "process substitution", (SEVAL_NONINT|SEVAL_NOHIST));
+-      /* leave subshell level intact for any exit trap */
+-    }
+-
+-#if !defined (HAVE_DEV_FD)
+-  /* Make sure we close the named pipe in the child before we exit. */
+-  close (open_for_read_in_child ? 0 : 1);
+-#endif /* !HAVE_DEV_FD */
+-
+-  last_command_exit_value = rc;
+-  rc = run_exit_trap ();
+-  exit (rc);
+-  /*NOTREACHED*/
++  return (pathname);
+ }
+ #endif /* PROCESS_SUBSTITUTION */

--- a/distro/bash/wasm-simple-command-clone.patch
+++ b/distro/bash/wasm-simple-command-clone.patch
@@ -1,0 +1,277 @@
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -4491,6 +4491,84 @@
+   return ret;
+ }
+ 
++/* Private marker used only in clone's copied SIMPLE_COM. */
++#define CMD_CLONE_CHILD_INTERNAL 0x10000
++
++typedef struct
++{
++  SIMPLE_COM *simple_command;
++  struct fd_bitmap *fds_to_close;
++  char *job_command;
++  int pipe_in;
++  int pipe_out;
++  int async;
++  pid_t old_last_async_pid;
++} EXECUTE_SIMPLE_ARGS;
++
++static int
++execute_simple_command_child (void *vargs)
++{
++  EXECUTE_SIMPLE_ARGS *args;
++  int function_value, jump, result;
++
++  args = (EXECUTE_SIMPLE_ARGS *)vargs;
++
++  /* The marker makes the recursive call enter immediately after the old
++     fork child setup, without repeating the parent-side DEBUG trap. */
++  args->simple_command->flags |= CMD_CLONE_CHILD_INTERNAL;
++
++  subshell_environment = SUBSHELL_FORK|SUBSHELL_IGNTRAP;
++  if (args->pipe_in != NO_PIPE || args->pipe_out != NO_PIPE)
++    subshell_environment |= SUBSHELL_PIPE;
++  if (args->async)
++    subshell_environment |= SUBSHELL_ASYNC;
++
++  if (args->fds_to_close)
++    close_fd_bitmap (args->fds_to_close);
++
++  stdin_redir |= args->pipe_in != NO_PIPE;
++  do_piping (args->pipe_in, args->pipe_out);
++
++#if defined (COPROCESS_SUPPORT)
++  coproc_closeall ();
++#endif
++
++#if defined (PROCESS_SUBSTITUTION)
++  clear_fifo_list ();
++#endif
++
++  last_asynchronous_pid = args->old_last_async_pid;
++  if (args->async)
++    subshell_level++;
++
++#if defined (JOB_CONTROL)
++  FREE (args->job_command);
++#endif
++
++  /* Word expansion, assignments, builtins, and functions can all jump to
++     the shell's global recovery buffers.  The inherited buffers name the
++     abandoned parent stack, so install child-local recovery points before
++     executing any of the simple command on this fresh clone stack. */
++  jump = setjmp_nosigs (top_level);
++  if (jump == 0 && return_catch_flag)
++    function_value = setjmp_nosigs (return_catch);
++  else
++    function_value = 0;
++
++  if (jump == EXITPROG || jump == EXITBLTIN || jump == ERREXIT)
++    result = last_command_exit_value;
++  else if (jump)
++    result = last_command_exit_value == EXECUTION_SUCCESS
++             ? EXECUTION_FAILURE : last_command_exit_value;
++  else if (function_value)
++    result = return_catch_value;
++  else
++    result = execute_simple_command (args->simple_command, NO_PIPE, NO_PIPE,
++                                     args->async, args->fds_to_close);
++  sh_exit (result);
++  return result;
++}
++
+ /* The meaty part of all the executions.  We have to start hacking the
+    real execution of commands here.  Fork a process, set things up,
+    execute the command. */
+@@ -4500,7 +4578,7 @@
+   WORD_LIST *words, *lastword;
+   char *command_line, *lastarg, *temp;
+   int first_word_quoted, result, builtin_is_special, already_forked, dofork;
+-  int fork_flags, cmdflags;
++  int clone_child, fork_flags, cmdflags;
+   pid_t old_last_async_pid;
+   sh_builtin_func_t *builtin;
+   SHELL_VAR *func;
+@@ -4507,39 +4585,43 @@
+   volatile int old_builtin, old_command_builtin;
+ 
++  clone_child = (simple_command->flags & CMD_CLONE_CHILD_INTERNAL) != 0;
++  simple_command->flags &= ~CMD_CLONE_CHILD_INTERNAL;
++
+   result = EXECUTION_SUCCESS;
+   special_builtin_failed = builtin_is_special = 0;
+   command_line = (char *)0;
+ 
+-  QUIT;
+-
+-  /* If we're in a function, update the line number information. */
+-  ADJUST_LINE_NUMBER ();
+-
+-  /* Remember what this command line looks like at invocation. */
+-  command_string_index = 0;
+-  if (the_printed_command)
+-    the_printed_command[0] = '\0';
+-  print_simple_command (simple_command);
++  if (clone_child == 0)
++    {
++      QUIT;
+ 
++      /* If we're in a function, update the line number information. */
++      ADJUST_LINE_NUMBER ();
++
++      /* Remember what this command line looks like at invocation. */
++      command_string_index = 0;
++      if (the_printed_command)
++        the_printed_command[0] = '\0';
++      print_simple_command (simple_command);
++
+ #if 0
+-  if (signal_in_progress (DEBUG_TRAP) == 0 && (this_command_name == 0 || (STREQ (this_command_name, "trap") == 0)))
++      if (signal_in_progress (DEBUG_TRAP) == 0 && (this_command_name == 0 || (STREQ (this_command_name, "trap") == 0)))
+ #else
+-  if (signal_in_progress (DEBUG_TRAP) == 0 && running_trap == 0)
++      if (signal_in_progress (DEBUG_TRAP) == 0 && running_trap == 0)
+ #endif
+-    {
+-      FREE (the_printed_command_except_trap);
+-      the_printed_command_except_trap = the_printed_command ? savestring (the_printed_command) : (char *)0;
+-    }
++        {
++          FREE (the_printed_command_except_trap);
++          the_printed_command_except_trap = the_printed_command ? savestring (the_printed_command) : (char *)0;
++        }
+ 
+-  /* Run the debug trap before each simple command, but do it after we
+-     update the line number information. */
+-  result = run_debug_trap ();
++      /* Run the debug trap before each simple command, but do it after we
++         update the line number information. */
++      result = run_debug_trap ();
+ #if defined (DEBUGGER)
+-  /* In debugging mode, if the DEBUG trap returns a non-zero status, we
+-     skip the command. */
+-  if (debugging_mode && result != EXECUTION_SUCCESS)
+-    return (EXECUTION_SUCCESS);
++      if (debugging_mode && result != EXECUTION_SUCCESS)
++        return (EXECUTION_SUCCESS);
+ #endif
++    }
+ 
+   cmdflags = simple_command->flags;
+ 
+@@ -4549,13 +4631,16 @@
+   last_command_subst_pid = NO_PID;
+   old_last_async_pid = last_asynchronous_pid;
+ 
+-  already_forked = 0;
++  already_forked = clone_child;
++  if (clone_child)
++    cmdflags |= CMD_NO_FORK;
+ 
+   /* If we're in a pipeline or run in the background, set DOFORK so we
+      make the child early, before word expansion.  This keeps assignment
+      statements from affecting the parent shell's environment when they
+      should not. */
+-  dofork = pipe_in != NO_PIPE || pipe_out != NO_PIPE || async;
++  dofork = clone_child == 0 &&
++           (pipe_in != NO_PIPE || pipe_out != NO_PIPE || async);
+ 
+   /* Something like `%2 &' should restart job 2 in the background, not cause
+      the shell to fork here. */
+@@ -4568,6 +4653,7 @@
+   if (dofork)
+     {
+       char *p, *xc;
++      EXECUTE_SIMPLE_ARGS *child_args;
+ 
+       /* Do this now, because execute_disk_command will do it anyway in the
+ 	 vast majority of cases. */
+@@ -4577,57 +4663,25 @@
+ 	 process/job associated with this child. */
+       fork_flags = async ? FORK_ASYNC : 0;
+       xc = the_printed_command_except_trap;
+-      if (make_child_fork (p = xc ? savestring (xc) : savestring (""), fork_flags) == 0)
+-	{
+-	  already_forked = 1;
+-	  cmdflags |= CMD_NO_FORK;
+-
+-	  /* We redo some of what make_child() does with SUBSHELL_IGNTRAP */
+-	  subshell_environment = SUBSHELL_FORK|SUBSHELL_IGNTRAP;	/* XXX */
+-	  if (pipe_in != NO_PIPE || pipe_out != NO_PIPE)
+-	    subshell_environment |= SUBSHELL_PIPE;
+-	  if (async)
+-	    subshell_environment |= SUBSHELL_ASYNC;
+-
+-	  /* We need to do this before piping to handle some really
+-	     pathological cases where one of the pipe file descriptors
+-	     is < 2. */
+-	  if (fds_to_close)
+-	    close_fd_bitmap (fds_to_close);
+-
+-	  /* If we fork because of an input pipe, note input pipe for later to
+-	     inhibit async commands from redirecting stdin from /dev/null */
+-	  stdin_redir |= pipe_in != NO_PIPE;
+-
+-	  do_piping (pipe_in, pipe_out);
+-	  pipe_in = pipe_out = NO_PIPE;
+-#if defined (COPROCESS_SUPPORT)
+-	  coproc_closeall ();
+-#endif
+-
+-#if defined (PROCESS_SUBSTITUTION)
+-	  clear_fifo_list ();		/* subshells don't inherit fifos */
+-#endif
+-
+-	  last_asynchronous_pid = old_last_async_pid;
+-
+-	  if (async)
+-	    subshell_level++;		/* not for pipes yet */
+-
+-#if defined (JOB_CONTROL)
+-	  FREE (p);			/* child doesn't use pointer */
+-#endif
+-	}
+-      else
+-	{
+-	  /* Don't let simple commands that aren't the last command in a
+-	     pipeline change $? for the rest of the pipeline (or at all). */
+-	  if (pipe_out != NO_PIPE)
+-	    result = last_command_exit_value;
+-	  close_pipes (pipe_in, pipe_out);
+-	  command_line = (char *)NULL;      /* don't free this. */
+-	  return (result);
+-	}
++      p = xc ? savestring (xc) : savestring ("");
++      child_args = (EXECUTE_SIMPLE_ARGS *)xmalloc (sizeof (*child_args));
++      child_args->simple_command = simple_command;
++      child_args->fds_to_close = fds_to_close;
++      child_args->job_command = p;
++      child_args->pipe_in = pipe_in;
++      child_args->pipe_out = pipe_out;
++      child_args->async = async;
++      child_args->old_last_async_pid = old_last_async_pid;
++      make_child (p, fork_flags, execute_simple_command_child, child_args);
++      free (child_args);
++
++      /* Don't let simple commands that aren't the last command in a
++         pipeline change $? for the rest of the pipeline (or at all). */
++      if (pipe_out != NO_PIPE)
++        result = last_command_exit_value;
++      close_pipes (pipe_in, pipe_out);
++      command_line = (char *)NULL;
++      return (result);
+     }
+ 
+   QUIT;		/* XXX */
+--- a/command.h
++++ b/command.h
+@@ -194,4 +194,7 @@
+ #define CMD_TRY_OPTIMIZING  0x8000	/* try to optimize this simple command */
+ 
++/* 0x10000 is reserved by the wasm callback-clone execution patch for an
++   internal child-continuation marker. */
++
+ /* What a command looks like. */
+ typedef struct command {

--- a/distro/default.nix
+++ b/distro/default.nix
@@ -68,6 +68,7 @@ lib.makeScope (scope: lib.callPackageWith ({ inherit lib pkgs; } // scope)) (
     apk-tools = callPackage ./apk-tools/package.nix {
       src = self.apk-tools-src;
     };
+    bash = callPackage ./bash/package.nix { };
     basic-init = callPackage ./basic-init/package.nix { };
     busybox = callPackage ./busybox/package.nix { };
     bzip2 = callPackage ./bzip2/package.nix { };


### PR DESCRIPTION
## What changed

- ports GNU Bash 5.3 to wasm Linux
- converts Bash process creation paths to callback-based clone continuations
- covers pipelines, substitutions, coprocesses, traps, job control, and interactive PTY behavior
- deliberately installs only `/bin/bash`; BusyBox remains the owner of `/bin/sh`

## Why

Bash should be an optional full shell alongside the minimal BusyBox userland, rather than replacing the system shell.

## Validation

The stacked `busybox-overlays` PR migrates these checks to APK-installed systems and validates Bash/BusyBox coexistence through apk-tools.