### PR TITLE
go: add wasm32 toolchain and VM integration check

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -32,6 +32,28 @@ Runtime overlays must not contain conflicting paths. If two fragments need to
 provide the same path, resolve that ownership in the packages rather than
 depending on image composition order.
 
+## Go packages
+
+Use the scope's `buildGoModule` exactly as you would use nixpkgs' builder:
+
+```nix
+{ buildGoModule }:
+
+buildGoModule {
+  pname = "example";
+  version = "1.0.0";
+  src = ./.;
+  vendorHash = null; # Replace with the fixed-output hash when dependencies exist.
+}
+```
+
+The builder uses the pinned native Go fork and produces `linux/wasm` programs
+with CGO disabled. Target binaries cannot run during a normal Nix build, so
+package checks are disabled by default; add a `vm-test` passthru check for
+runtime coverage. The default development shell exposes the same toolchain and
+target environment, so ordinary commands such as `go build` produce matching
+WebAssembly binaries.
+
 ## Building and running
 
 - **Stage new files before running any Nix command.** Flakes copy a Git worktree

--- a/flake.nix
+++ b/flake.nix
@@ -79,13 +79,19 @@
           default = pkgs.mkShellNoCC {
             packages = [
               formatter
+              wasmpkgs.go-toolchain.package
               wasmpkgs.llvm-toolchain
               pkgs.cmake
               pkgs.ninja
               pkgs.nodejs
               pkgs.pnpm_11
             ];
-            env.sysroot = "${wasmpkgs.sysroot}";
+            env = {
+              inherit (wasmpkgs.platform.system.go) GOOS GOARCH;
+              CGO_ENABLED = "0";
+              GOTOOLCHAIN = "local";
+              sysroot = "${wasmpkgs.sysroot}";
+            };
           };
 
         }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -51,6 +51,9 @@ lib.makeScope (scope: lib.callPackageWith ({ inherit lib pkgs; } // scope)) (
 
     # A pinned nightly rustc with a from-source std for the wasm target.
     rust-toolchain = callPackage ./rust-toolchain/package.nix { };
+    # A native forked Go compiler plus nixpkgs' module builder for linux/wasm.
+    go-toolchain = callPackage ./go-toolchain/package.nix { };
+    buildGoModule = self.go-toolchain.buildGoModule;
 
     # userland:
     basic-init = callPackage ./basic-init/package.nix { };
@@ -60,6 +63,7 @@ lib.makeScope (scope: lib.callPackageWith ({ inherit lib pkgs; } // scope)) (
     dropbear = callPackage ./dropbear/package.nix { };
     file = callPackage ./file/package.nix { };
     git = callPackage ./git/package.nix { };
+    go-smoke = callPackage ./go-smoke/package.nix { };
     jq = callPackage ./jq/package.nix { };
     lua = callPackage ./lua/package.nix { };
     make = callPackage ./make/package.nix { };

--- a/packages/go-smoke/go.mod
+++ b/packages/go-smoke/go.mod
@@ -1,0 +1,3 @@
+module go-smoke
+
+go 1.28

--- a/packages/go-smoke/package.nix
+++ b/packages/go-smoke/package.nix
@@ -1,0 +1,50 @@
+# The Go port's own integration suite, built through our nixpkgs-native module
+# builder and booted as PID 1. It covers the runtime surface most likely to
+# regress across compiler, kernel, and process-ABI changes.
+{
+  buildGoModule,
+  go-toolchain,
+  vm-test,
+}:
+
+let
+  go-smoke = buildGoModule {
+    pname = "go-smoke";
+    version = "0.0.0";
+    src = go-toolchain.src + "/misc/wasm/linux";
+    vendorHash = null;
+
+    postPatch = ''
+      install -m644 ${./go.mod} go.mod
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      go test -c -ldflags=-buildid= -o init .
+      go build -ldflags=-buildid= -o child ./testdata/child.go
+      go build -ldflags=-buildid= -o grandchild ./testdata/grandchild.go
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      install -m755 init child grandchild $out/bin/
+      runHook postInstall
+    '';
+
+    passthru.checks.integration = vm-test.vmTest {
+      name = "go-integration";
+      cpus = 2;
+      initramfs = vm-test.mkInitramfs {
+        name = "go-integration";
+        init = "${go-smoke}/bin/init";
+        files = {
+          "/child" = "${go-smoke}/bin/child";
+          "/grandchild" = "${go-smoke}/bin/grandchild";
+        };
+      };
+    };
+  };
+in
+go-smoke

--- a/packages/go-toolchain/package.nix
+++ b/packages/go-toolchain/package.nix
@@ -1,0 +1,71 @@
+# The Go toolchain for linux/wasm is a native compiler whose forked linker and
+# runtime know the target. Keep the compiler on the build platform and teach
+# nixpkgs' ordinary module builder about the wasm stdenv and target variables;
+# building Go itself with GOOS=linux GOARCH=wasm would incorrectly try to make
+# the host cmd/* tools into wasm executables.
+{
+  lib,
+  pkgs,
+  platform,
+  stdenv,
+  src ? pkgs.fetchFromGitHub {
+    owner = "tombl";
+    repo = "go";
+    rev = "1cb069694ffe524c4c46bd303b3657aa31a5be3e";
+    hash = "sha256-QKnr9hhUWaZdjFkY092OIeHjSrR0WcjHBxFH77PU9OY=";
+  },
+}:
+
+let
+  nativeGo = pkgs.go_1_27.overrideAttrs (
+    _finalAttrs: previousAttrs: {
+      pname = "go-wasm-linux";
+      version = "1.28-devel-1cb069694f";
+      inherit src;
+
+      # Development checkouts derive this from Git history. fetchFromGitHub has
+      # no .git directory, so provide the version make.bash and cmd/go require.
+      postPatch = (previousAttrs.postPatch or "") + ''
+        printf '%s\n' 'devel go1.28-1cb069694f' > VERSION
+      '';
+
+      env = previousAttrs.env // {
+        # Go tip requires the previous stable release as its bootstrap compiler;
+        # nixpkgs' go_1_27 expression still bootstraps with Go 1.24.
+        GOROOT_BOOTSTRAP = "${pkgs.go_1_26}/share/go";
+        GOTOOLCHAIN = "local";
+      };
+    }
+  );
+
+  # buildGoModule reads these attributes from its `go` argument. Adding them
+  # to the derivation value does not rebuild the native compiler for the target.
+  targetGo = nativeGo // {
+    inherit (platform.system.go) GOOS GOARCH;
+    CGO_ENABLED = 0;
+    meta = nativeGo.meta // {
+      platforms = [ platform.system.system ];
+    };
+  };
+
+  nixpkgsBuilder = pkgs.buildGo127Module.override {
+    go = targetGo;
+    inherit stdenv;
+  };
+
+  # Cross-built tests cannot run during a normal derivation. Packages can opt
+  # back in, but platform behavior belongs in explicit vm-test checks.
+  buildGoModule = lib.makeOverridable (
+    args:
+    nixpkgsBuilder (
+      if builtins.isFunction args then
+        finalAttrs: { doCheck = false; } // args finalAttrs
+      else
+        { doCheck = false; } // args
+    )
+  );
+in
+{
+  package = nativeGo;
+  inherit src targetGo buildGoModule;
+}


### PR DESCRIPTION
Pin the wasm-linux Go fork at the process-argument syscall ABI and package the compiler as a native build-platform tool. Adapt nixpkgs’ `buildGoModule` to target `linux/wasm` through the distro stdenv while preserving the standard module/vendor interface.

Expose the same target environment in `nix develop` and boot Go’s upstream wasm/Linux integration suite as PID 1 in a two-vCPU VM.

Validation:
- upstream `misc/wasm/linux/run.bash` (two CPUs)
- `nix fmt`
- `nix flake check --no-build`
- `nix build .#checks.x86_64-linux.formatting`
- `nix build .#checks.x86_64-linux.go-smoke-check-integration`
- ordinary `buildGoModule` consumer build plus `wasm-validate`
- aarch64-linux and aarch64-darwin Go package evaluation