### PR TITLE
go: add ecosystem compatibility tests

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -54,6 +54,7 @@ lib.makeScope (scope: lib.callPackageWith ({ inherit lib pkgs; } // scope)) (
     # A native forked Go compiler plus nixpkgs' module builder for linux/wasm.
     go-toolchain = callPackage ./go-toolchain/package.nix { };
     buildGoModule = self.go-toolchain.buildGoModule;
+    go-compat = callPackage ./go-compat/package.nix { };
 
     # userland:
     basic-init = callPackage ./basic-init/package.nix { };
@@ -64,6 +65,7 @@ lib.makeScope (scope: lib.callPackageWith ({ inherit lib pkgs; } // scope)) (
     file = callPackage ./file/package.nix { };
     git = callPackage ./git/package.nix { };
     go-smoke = callPackage ./go-smoke/package.nix { };
+    go-ecosystem = callPackage ./go-ecosystem/package.nix { };
     jq = callPackage ./jq/package.nix { };
     lua = callPackage ./lua/package.nix { };
     make = callPackage ./make/package.nix { };

--- a/packages/go-compat/package.nix
+++ b/packages/go-compat/package.nix
@@ -1,0 +1,190 @@
+# Exact compatibility source for the foundational golang.org/x modules. The
+# wasm Linux Go port has a deliberately unusual split ABI: Go pointers are
+# 64-bit, while the kernel and musl structures are ILP32. Generate x/sys types
+# from the distro headers with cgo's 32-bit type reader, but compile and run the
+# resulting package with the normal 64-bit-pointer Go wasm architecture.
+{
+  pkgs,
+  go-toolchain,
+  sysroot,
+}:
+
+let
+  xSysUpstream = pkgs.fetchFromGitHub {
+    owner = "golang";
+    repo = "sys";
+    rev = "v0.47.0";
+    hash = "sha256-St0+knON6NE8ApWfjOjzw4O8wInQ23f1bNRy7pp2Vpo=";
+  };
+
+  generationCC = "${pkgs.llvmPackages.clang-unwrapped}/bin/clang";
+
+  xSys =
+    pkgs.runCommand "golang-x-sys-0.47.0-wasm-linux"
+      {
+        nativeBuildInputs = [
+          go-toolchain.package
+          pkgs.bash
+          pkgs.gawk
+          pkgs.gnused
+          pkgs.patch
+        ];
+      }
+      ''
+        cp -r ${xSysUpstream} $out
+        chmod -R u+w $out
+        patch --ignore-whitespace -p1 -d $out < ${./x-sys-types-wasm.patch}
+        substituteInPlace $out/cpu/cpu_linux.go \
+          --replace-fail '!arm64' '!arm64 && !wasm'
+        cd $out/unix
+        export HOME=$TMPDIR
+        export GOCACHE=$TMPDIR/go-cache
+        mkdir -p linux/abi
+        for bit in $(seq 0 63); do
+          printf '#define BITFIELD_MASK_%s (1ULL << %s)\n' "$bit" "$bit"
+        done > linux/abi/abi.h
+
+        # wasm uses asm-generic syscall numbers and the ILP32 Linux constant
+        # encodings. The descriptions and generated wrappers are architecture
+        # neutral; the type file below comes from the actual distro headers.
+        cp zerrors_linux_386.go zerrors_linux_wasm.go
+        substituteInPlace zerrors_linux_wasm.go \
+          --replace-fail '386 && linux' 'wasm && linux'
+        cp zsysnum_linux_arm64.go zsysnum_linux_wasm.go
+        substituteInPlace zsysnum_linux_wasm.go \
+          --replace-fail 'arm64 && linux' 'wasm && linux'
+
+          # cgo cannot decode a wasm object even in -godefs mode. Generate an ELF
+          # object with the equivalent little-endian ILP32 data model and 8-byte
+          # i64 alignment, while preprocessing the distro's actual wasm headers.
+          # GOARCH_TARGET keeps mkpost's architecture cleanups on wasm.
+          GOOS=linux GOARCH=arm GOARCH_TARGET=wasm CGO_ENABLED=1 CC=${generationCC} \
+            go tool cgo -godefs -- -Wall '-Wno-error=#warnings' -static \
+              --target=armv7-none-linux-gnueabihf --sysroot=${sysroot} \
+              -U__arm__ -U__ARM_EABI__ -D__wasm__=1 \
+              -fsigned-char '-D__SIZE_TYPE__=long unsigned int' \
+              -I$PWD/linux linux/types.go \
+            | env -u GOOS -u GOARCH GOOS_TARGET=linux GOARCH_TARGET=wasm \
+              GOLANG_SYS_BUILD=docker go run mkpost.go \
+            > ztypes_linux_wasm.go
+          rm ztypes_linux.go
+
+        # cgo cannot name musl's deliberately opaque struct stat after the
+        # synthetic target has had its ARM identity removed. Its layout is
+        # nevertheless a stable part of the wasm-linux ABI and is shared with
+        # the standard library port.
+        substituteInPlace ztypes_linux_wasm.go \
+          --replace-fail 'type Stat_t _cgopackage.Incomplete' 'type Stat_t struct {
+              Dev       uint64
+              Ino       uint64
+              Mode      uint32
+              Nlink     uint32
+              Uid       uint32
+              Gid       uint32
+              Rdev      uint64
+              X__pad    uint64
+              Size      int64
+              Blksize   int32
+              X__pad2   int32
+              Blocks    int64
+              Atim      Timespec
+              Mtim      Timespec
+              Ctim      Timespec
+              X__unused [2]uint32
+          }'
+
+        substituteInPlace endian_little.go \
+          --replace-fail '386 || amd64' '386 || wasm || amd64'
+
+        cp syscall_linux_arm64.go syscall_linux_wasm.go
+        substituteInPlace syscall_linux_wasm.go \
+          --replace-fail 'arm64 && linux' 'wasm && linux' \
+          --replace-fail 'Nsec: timeout.Usec * 1000' 'Nsec: int32(timeout.Usec * 1000)' \
+          --replace-fail 'Nsec: nsec}' 'Nsec: int32(nsec)}' \
+          --replace-fail 'func (r *PtraceRegs) PC() uint64 { return r.Pc }' "" \
+          --replace-fail 'func (r *PtraceRegs) SetPC(pc uint64) { r.Pc = pc }' "" \
+          --replace-fail 'iov.Len = uint64(length)' 'iov.Len = uint32(length)' \
+          --replace-fail 'msghdr.Controllen = uint64(length)' 'msghdr.Controllen = uint32(length)' \
+          --replace-fail 'msghdr.Iovlen = uint64(length)' 'msghdr.Iovlen = int32(length)' \
+          --replace-fail 'cmsg.Len = uint64(length)' 'cmsg.Len = uint32(length)' \
+          --replace-fail 'rsa.Service_name_len = uint64(length)' 'rsa.Service_name_len = uint32(length)'
+
+        # fanotifyMark's uint64 mask makes its generated calling sequence
+        # architecture-specific, so it is absent from the merged Linux file.
+        printf '\n//sys\tfanotifyMark(fd int, flags uint, mask uint64, dirFd int, pathname *byte) (err error)\n' \
+          >> syscall_linux_wasm.go
+        printf '//sys\tFallocate(fd int, mode uint32, off int64, len int64) (err error)\n' \
+          >> syscall_linux_wasm.go
+        printf '//sys\tTee(rfd int, wfd int, len int, flags int) (n int64, err error)\n' \
+          >> syscall_linux_wasm.go
+
+        # wasm forwards raw calls through the forked standard syscall package;
+        # the architecture assembly shims used elsewhere cannot express the
+        # wasm host-call instruction sequence.
+        substituteInPlace syscall_unix_gc.go \
+          --replace-fail '(linux && !ppc64 && !ppc64le)' '(linux && !ppc64 && !ppc64le && !wasm)'
+        substituteInPlace syscall_linux_gc.go \
+          --replace-fail 'linux && gc' 'linux && gc && !wasm'
+        install -m644 ${./syscall_gc_wasm.go} syscall_gc_wasm.go
+
+        env -u GOOS -u GOARCH GOOS_TARGET=linux GOLANG_SYS_BUILD=docker \
+          go run mksyscall.go -tags linux,wasm syscall_linux_wasm.go \
+          > zsyscall_linux_wasm.go
+
+        gofmt -w syscall_linux_wasm.go syscall_gc_wasm.go \
+          ztypes_linux_wasm.go zsyscall_linux_wasm.go
+      '';
+
+  xTerm = pkgs.fetchFromGitHub {
+    owner = "golang";
+    repo = "term";
+    rev = "v0.45.0";
+    hash = "sha256-vPBeJkepEZ1D9k4oaV20IuQlVmfAFv15KQgnhl9MNgw=";
+  };
+
+  xNetUpstream = pkgs.fetchFromGitHub {
+    owner = "golang";
+    repo = "net";
+    rev = "v0.57.0";
+    hash = "sha256-gKo8UMw4hfETBHm8N5GOfuNadse9TWEQXJo2YWq5bY4=";
+  };
+
+  xNet = pkgs.runCommand "golang-x-net-0.57.0-wasm-linux" { } ''
+    cp -r ${xNetUpstream} $out
+    chmod -R u+w $out
+    substituteInPlace $out/internal/socket/cmsghdr_linux_32bit.go \
+      --replace-fail 'ppc) && linux' 'ppc || wasm) && linux'
+    substituteInPlace $out/internal/socket/iovec_32bit.go \
+      --replace-fail 'ppc) && (darwin' 'ppc || wasm) && (darwin'
+    substituteInPlace $out/internal/socket/msghdr_linux_32bit.go \
+      --replace-fail 'ppc) && linux' 'ppc || wasm) && linux'
+    substituteInPlace $out/internal/socket/rawconn_mmsg.go \
+      --replace-fail '//go:build linux' '//go:build linux && !wasm'
+    substituteInPlace $out/internal/socket/rawconn_nommsg.go \
+      --replace-fail '//go:build !linux' '//go:build !linux || wasm'
+    substituteInPlace $out/internal/socket/sys_linux.go \
+      --replace-fail '!s390x && !386' '!s390x && !386 && !wasm'
+    substituteInPlace $out/internal/socket/mmsghdr_unix.go \
+      --replace-fail 'aix || linux || netbsd' 'aix || (linux && !wasm) || netbsd'
+    install -m644 ${./x-net-zsys_linux_wasm.go} \
+      $out/internal/socket/zsys_linux_wasm.go
+    cp $out/ipv4/zsys_linux_arm.go $out/ipv4/zsys_linux_wasm.go
+    cp $out/ipv6/zsys_linux_arm.go $out/ipv6/zsys_linux_wasm.go
+  '';
+
+  xCrypto = pkgs.fetchFromGitHub {
+    owner = "golang";
+    repo = "crypto";
+    rev = "v0.54.0";
+    hash = "sha256-7dZVbrJ4lVKThJWaOGc4bJTdzJBlRLAx/vSHeWFyor8=";
+  };
+in
+{
+  package = xSys;
+  inherit
+    xCrypto
+    xNet
+    xSys
+    xTerm
+    ;
+}

--- a/packages/go-compat/syscall_gc_wasm.go
+++ b/packages/go-compat/syscall_gc_wasm.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && wasm && gc
+
+package unix
+
+import "syscall"
+
+func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
+	return syscall.Syscall(trap, a1, a2, a3)
+}
+
+func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno) {
+	return syscall.Syscall6(trap, a1, a2, a3, a4, a5, a6)
+}
+
+func RawSyscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
+	return syscall.RawSyscall(trap, a1, a2, a3)
+}
+
+func RawSyscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno) {
+	return syscall.RawSyscall6(trap, a1, a2, a3, a4, a5, a6)
+}
+
+func SyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr) {
+	r1, r2, _ = syscall.Syscall(trap, a1, a2, a3)
+	return
+}
+
+func RawSyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr) {
+	r1, r2, _ = syscall.RawSyscall(trap, a1, a2, a3)
+	return
+}

--- a/packages/go-compat/x-net-zsys_linux_wasm.go
+++ b/packages/go-compat/x-net-zsys_linux_wasm.go
@@ -1,0 +1,34 @@
+// Code generated from the wasm-linux ILP32 socket ABI; DO NOT EDIT.
+
+package socket
+
+type iovec struct {
+	Base *byte
+	Len  uint32
+}
+
+type msghdr struct {
+	Name       *byte
+	Namelen    uint32
+	Iov        *iovec
+	Iovlen     uint32
+	Control    *byte
+	Controllen uint32
+	Flags      int32
+}
+
+type mmsghdr struct {
+	Hdr msghdr
+	Len uint32
+}
+
+type cmsghdr struct {
+	Len   uint32
+	Level int32
+	Type  int32
+}
+
+const (
+	sizeofIovec  = 0x8
+	sizeofMsghdr = 0x1c
+)

--- a/packages/go-compat/x-sys-types-wasm.patch
+++ b/packages/go-compat/x-sys-types-wasm.patch
@@ -1,0 +1,27 @@
+diff --git a/unix/linux/types.go b/unix/linux/types.go
+index 4a49cb1..71e2bd7 100644
+--- a/unix/linux/types.go
++++ b/unix/linux/types.go
+@@ -97 +97,3 @@
+-#include <asm/ptrace.h>
++#if !defined(__wasm__)
++#include <asm/ptrace.h>
++#endif
+@@ -313 +315,8 @@ struct my_sockaddr_nfc_llcp {
+-#ifdef __ARM_EABI__
++#if defined(__wasm__)
++typedef struct {
++	uint32_t unavailable;
++} PtraceRegs;
++typedef unsigned long __cpu_mask;
++#define __CPU_SETSIZE CPU_SETSIZE
++#define __NCPUBITS (8 * sizeof(__cpu_mask))
++#elif defined(__ARM_EABI__)
+@@ -417,2 +426,7 @@ struct perf_event_attr_go {
++#if defined(__wasm__)
++	int32_t f_tfree;
++	ino_t f_tinode;
++#else
+  __daddr_t f_tfree;
+  __ino_t f_tinode;
++#endif

--- a/packages/go-ecosystem/bbolt_wasm.go
+++ b/packages/go-ecosystem/bbolt_wasm.go
@@ -1,0 +1,14 @@
+//go:build wasm
+
+package common
+
+const (
+	// MaxMapSize is the largest addressable mapping. The kernel currently
+	// rejects mmap, but this remains the correct fail-closed ILP32 bound.
+	MaxMapSize = 0x7fffffff
+
+	// MaxAllocSize is the maximum synthetic array size used by unsafe slice
+	// conversions. Go pointers are 64-bit on this port even though the kernel
+	// ABI is ILP32.
+	MaxAllocSize = 0x7fffffff
+)

--- a/packages/go-ecosystem/guest-test.sh
+++ b/packages/go-ecosystem/guest-test.sh
@@ -1,0 +1,115 @@
+#!/bin/busybox sh
+
+fail() {
+  printf 'go ecosystem guest failure: %s\n' "$*"
+  echo "::vm-test::fail"
+  while :; do :; done
+}
+
+export PATH=/bin
+export HOME=/tmp/home
+export TMPDIR=/tmp
+
+mount -t devtmpfs devtmpfs /dev || fail "mounting devtmpfs failed"
+mount -t proc proc /proc || fail "mounting proc failed"
+/vm-test-setup-dev-fd || fail "creating /dev/fd links failed"
+mkdir -p "$HOME" || fail "creating HOME failed"
+
+for test_binary in /bin/*.test; do
+  printf 'running %s\n' "$test_binary"
+  test_skip='$^'
+  case "$test_binary" in
+  */age-age.test)
+    # The examples open source-tree-relative fixtures which are intentionally
+    # not part of this binary-only rootfs. Run every ordinary test instead.
+    test_run='^Test'
+    ;;
+  */caddy-caddy.test)
+    # Skip tests which need an IPv6 localhost resolver or source-tree-relative
+    # fixtures. The file-server smoke below exercises Caddy's native bind path.
+    test_run='^(TestUnsyncedConfigAccess|TestLoadConcurrent|TestAdminHandler.*|TestNewAdminHandlerRouterRegistration|TestAdminRouterProvisioning|TestAllowedOriginsUnixSocket|TestRemoteAdminAccessControlPathSegmentMatching|TestUnsyncedConfigAccessCanonicalArrayIndices|TestReplacer|TestReplacerSet|TestReplacerReplaceKnown|TestReplacerDelete|TestReplacerMap|TestReplacerNewWithoutFile)$'
+    ;;
+  */caddy-caddyconfig-caddyfile.test)
+    test_run='^(TestFormatter|TestLexer|TestParseVariadic|TestAllTokens|TestEnvironmentReplacement|TestRejectsGlobalMatcher|TestRejectAnonymousImportBlock|TestAcceptSiteImportWithBraces|TestDispenser_.*)$'
+    ;;
+  */fzf-src.test)
+    test_run='.'
+    # TestHistory assumes an unprivileged user, subprocess output is not
+    # available yet, and the randomized ANSI stress tests currently overflow
+    # Go's wasm split stack on SMP guests.
+    test_skip='^(TestHistory|TestReadFromCommand|TestNextAnsiEscapeSequence_Fuzz_)'
+    ;;
+  */x-crypto-ssh.test)
+    test_run='Test(Buffer|ParseCert|ValidateCert|CheckCert|CertSign|MinPayload|WriteExtended|DefaultCiphers|PacketCiphers|CBCOracle|CVE|CompatibleAlgo|PickSignature|VerifyHostKeySignature|FindAgreedAlgorithms|KeyFormatAlgorithms|HandshakeErrorHandling|HandshakePendingPackets|PickIncompatible|ParseGSSAPI|BuildMIC|AutoPortListenBroken|ClientImplements|ClientDialContext|ReadVersion|ExchangeVersions|TransportMax)'
+    ;;
+  */x-net-proxy.test)
+    test_run='Test(PerHost|FromEnvironment)'
+    ;;
+  */x-net-websocket.test)
+    # httptest prefers IPv6 loopback, which this kernel does not enable. Keep
+    # the framing and handshake coverage; Caddy's smoke covers server startup.
+    test_run='^(TestSecWebSocketAccept|TestHybi.*|TestParseAuthority)$'
+    ;;
+  */x-sys-unix.test)
+    # Exercise the supported file, descriptor, identity, and path syscall ABI.
+    # mmap, vectored I/O, epoll, and several time syscalls are not implemented
+    # or ABI-compatible yet and are deliberately outside this positive matrix.
+    test_run='^Test(Env|Uname|StatFieldNames|Devices|Auxv|ErrnoSignalName|SignalNum|FcntlInt|FcntlFlock|Rlimit|SeekFailure|Dup|Getwd|Fstatat|Fchmodat|Mkdev|Pipe|Renameat|Faccessat|Openat2)$'
+    ;;
+  */x-term-x-term.test)
+    # devpts is not mounted in this minimal initramfs.
+    test_run='^TestIsTerminalTempFile$'
+    ;;
+  */yq-pkg-yqlib.test)
+    test_run='.'
+    # Scenario tests are generated from the documentation tree, which is not
+    # present in this binary-only rootfs. Keep the parser, node, and encoders.
+    test_skip='(Scenarios$|^TestRecipes$|^TestChangeOwner)'
+    ;;
+  *) test_run='.' ;;
+  esac
+  "$test_binary" -test.run="$test_run" -test.skip="$test_skip" -test.timeout=120s ||
+    fail "$test_binary exited with $?"
+done
+
+printf 'smoking yq\n'
+echo 'answer: 42' | yq -r '.answer' >/tmp/yq.out || fail "yq failed"
+grep -qx 42 /tmp/yq.out || fail "yq returned the wrong value"
+
+printf 'smoking age\n'
+printf 'secret payload\n' >/tmp/age.plain
+age-keygen -o /tmp/age.key >/tmp/age-keygen.log 2>&1 || fail "age-keygen failed"
+age-keygen -y /tmp/age.key >/tmp/age.recipient || fail "age recipient extraction failed"
+age -R /tmp/age.recipient -o /tmp/age.enc /tmp/age.plain || fail "age encryption failed"
+age -d -i /tmp/age.key -o /tmp/age.out /tmp/age.enc || fail "age decryption failed"
+grep -qx 'secret payload' /tmp/age.out || fail "age roundtrip changed the payload"
+
+printf 'smoking restic\n'
+restic version >/tmp/restic.out 2>&1 || fail "restic startup failed"
+grep -q '^restic ' /tmp/restic.out || fail "restic returned an unexpected version"
+
+printf 'smoking caddy\n'
+mkdir -p /tmp/caddy-root
+printf 'served by caddy\n' >/tmp/caddy-root/index.html
+caddy file-server --listen :8080 --root /tmp/caddy-root >/tmp/caddy.log 2>&1 &
+caddy_pid=$!
+caddy_ready=false
+for _attempt in 1 2 3 4 5 6 7 8 9 10; do
+  if kill -0 "$caddy_pid" 2>/dev/null && grep -q 'Caddy serving static files' /tmp/caddy.log; then
+    caddy_ready=true
+    break
+  fi
+  sleep 1
+done
+kill "$caddy_pid" 2>/dev/null || true
+wait "$caddy_pid" 2>/dev/null || true
+[ "$caddy_ready" = true ] || fail "caddy did not start its file server: $(cat /tmp/caddy.log)"
+
+printf 'smoking fzf\n'
+echo 'alpha
+needle
+omega' | fzf --filter=need >/tmp/fzf.out || fail "fzf failed"
+grep -qx needle /tmp/fzf.out || fail "fzf returned the wrong match"
+
+echo "::vm-test::pass"
+while :; do :; done

--- a/packages/go-ecosystem/package.nix
+++ b/packages/go-ecosystem/package.nix
@@ -1,0 +1,276 @@
+{
+  buildGoModule,
+  busybox,
+  go-compat,
+  lib,
+  pkgs,
+  vm-test,
+}:
+
+let
+  replaceXSys = ''
+    chmod -R u+w vendor
+    rm -rf vendor/golang.org/x/sys
+    mkdir -p vendor/golang.org/x
+    cp -r ${go-compat.xSys} vendor/golang.org/x/sys
+    chmod -R u+w vendor/golang.org/x/sys
+
+    # go-isatty treats every wasm architecture as a browser-style sandbox.
+    # linux/wasm has the ordinary Unix ioctl implementation instead.
+    if test -f vendor/github.com/mattn/go-isatty/isatty_others.go; then
+      sed -i \
+        -e 's/|| wasm ||/|| (wasm \&\& !linux) ||/' \
+        -e 's/|| wasm)/|| (wasm \&\& !linux))/' \
+        -e 's/ tinygo wasm wasip1/ tinygo wasm,!linux wasip1/' \
+        -e 's/ tinygo wasm$/ tinygo wasm,!linux/' \
+        vendor/github.com/mattn/go-isatty/isatty_others.go
+      grep -q 'wasm && !linux' vendor/github.com/mattn/go-isatty/isatty_others.go
+    fi
+
+    azure_runtime=vendor/github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime
+    if test -f "$azure_runtime/transport_default_dialer_other.go"; then
+      substituteInPlace "$azure_runtime/transport_default_dialer_other.go" \
+        --replace-fail '//go:build !wasm' '//go:build !wasm || (linux && wasm)'
+    fi
+
+    if test -d vendor/golang.org/x/net/internal/socket; then
+      xnet_socket=vendor/golang.org/x/net/internal/socket
+      substituteInPlace "$xnet_socket/cmsghdr_linux_32bit.go" \
+        --replace-fail 'ppc) && linux' 'ppc || wasm) && linux'
+      substituteInPlace "$xnet_socket/iovec_32bit.go" \
+        --replace-fail 'ppc) && (darwin' 'ppc || wasm) && (darwin'
+      substituteInPlace "$xnet_socket/msghdr_linux_32bit.go" \
+        --replace-fail 'ppc) && linux' 'ppc || wasm) && linux'
+      substituteInPlace "$xnet_socket/rawconn_mmsg.go" \
+        --replace-fail '//go:build linux' '//go:build linux && !wasm'
+      substituteInPlace "$xnet_socket/rawconn_nommsg.go" \
+        --replace-fail '//go:build !linux' '//go:build !linux || wasm'
+      substituteInPlace "$xnet_socket/sys_linux.go" \
+        --replace-fail '!s390x && !386' '!s390x && !386 && !wasm'
+      substituteInPlace "$xnet_socket/mmsghdr_unix.go" \
+        --replace-fail 'aix || linux || netbsd' 'aix || (linux && !wasm) || netbsd'
+      install -m644 ${../go-compat/x-net-zsys_linux_wasm.go} \
+        "$xnet_socket/zsys_linux_wasm.go"
+      cp vendor/golang.org/x/net/ipv4/zsys_linux_arm.go \
+        vendor/golang.org/x/net/ipv4/zsys_linux_wasm.go
+      cp vendor/golang.org/x/net/ipv6/zsys_linux_arm.go \
+        vendor/golang.org/x/net/ipv6/zsys_linux_wasm.go
+    fi
+
+    bbolt_common=vendor/go.etcd.io/bbolt/internal/common
+    if test -d "$bbolt_common"; then
+      install -m644 ${./bbolt_wasm.go} "$bbolt_common/bolt_wasm.go"
+    fi
+  '';
+
+  mkTests =
+    {
+      name,
+      src,
+      packages,
+      vendorHash ? null,
+    }:
+    buildGoModule {
+      pname = "go-${name}-tests";
+      version = "0.0.0";
+      inherit src vendorHash;
+
+      postConfigure = lib.optionalString (name != "x-sys") ''
+        ${replaceXSys}
+      '';
+
+      buildPhase = ''
+        runHook preBuild
+        ${lib.concatMapStringsSep "\n" (
+          package:
+          let
+            binary = if package == "." then name else lib.replaceStrings [ "./" "/" ] [ "" "-" ] package;
+          in
+          "go test -c -ldflags=-buildid= -o ${name}-${binary}.test ${package}"
+        ) packages}
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        install -m755 *.test $out/bin/
+        runHook postInstall
+      '';
+    };
+
+  libraryTests = {
+    x-sys = mkTests {
+      name = "x-sys";
+      src = go-compat.xSys;
+      packages = [ "./unix" ];
+    };
+
+    x-term = mkTests {
+      name = "x-term";
+      src = go-compat.xTerm;
+      packages = [ "." ];
+      vendorHash = "sha256-zKah7N80wT2ZZIzcw0rjh/gEL6xVxii8CdoT13b9fLY=";
+    };
+
+    x-net = mkTests {
+      name = "x-net";
+      src = go-compat.xNet;
+      packages = [
+        "./dns/dnsmessage"
+        "./http/httpguts"
+        "./http/httpproxy"
+        "./proxy"
+        "./websocket"
+      ];
+      vendorHash = "sha256-JSklT/mRq/bDEi11Z63v9HkVt9RS+fYuj/lhupMdK3s=";
+    };
+
+    x-crypto = mkTests {
+      name = "x-crypto";
+      src = go-compat.xCrypto;
+      packages = [
+        "./argon2"
+        "./bcrypt"
+        "./chacha20poly1305"
+        "./ssh"
+      ];
+      vendorHash = "sha256-BW8Qqz/Fq2SNVV3rBFBozPzDdLLr36SXTxj6ZcdXVdo=";
+    };
+  };
+
+  applicationTests = {
+    yq = mkTests {
+      name = "yq";
+      src = pkgs.yq-go.src;
+      packages = [ "./pkg/yqlib" ];
+      vendorHash = pkgs.yq-go.goModules.outputHash;
+    };
+
+    age = mkTests {
+      name = "age";
+      src = pkgs.age.src;
+      packages = [ "." ];
+      vendorHash = pkgs.age.goModules.outputHash;
+    };
+
+    restic = mkTests {
+      name = "restic";
+      src = pkgs.restic.src;
+      packages = [
+        "./internal/crypto"
+        "./internal/restic"
+      ];
+      vendorHash = pkgs.restic.goModules.outputHash;
+    };
+
+    caddy = mkTests {
+      name = "caddy";
+      src = pkgs.caddy.src;
+      packages = [
+        "."
+        "./caddyconfig/caddyfile"
+      ];
+      vendorHash = pkgs.caddy.goModules.outputHash;
+    };
+
+    fzf = mkTests {
+      name = "fzf";
+      src = pkgs.fzf.src;
+      packages = [ "./src" ];
+      vendorHash = pkgs.fzf.goModules.outputHash;
+    };
+  };
+
+  tests = libraryTests // applicationTests;
+
+  mkCandidate =
+    {
+      name,
+      upstream,
+      subPackages,
+      tags ? [ ],
+      ldflags ? [
+        "-s"
+        "-w"
+      ],
+    }:
+    buildGoModule {
+      pname = name;
+      inherit (upstream) version src;
+      vendorHash = upstream.goModules.outputHash;
+      inherit
+        ldflags
+        subPackages
+        tags
+        ;
+      postConfigure = replaceXSys;
+    };
+
+  candidates = {
+    yq = mkCandidate {
+      name = "yq";
+      upstream = pkgs.yq-go;
+      subPackages = [ "." ];
+    };
+
+    age = mkCandidate {
+      name = "age";
+      upstream = pkgs.age;
+      subPackages = [
+        "./cmd/age"
+        "./cmd/age-keygen"
+      ];
+    };
+
+    restic = mkCandidate {
+      name = "restic";
+      upstream = pkgs.restic;
+      subPackages = [ "./cmd/restic" ];
+    };
+
+    caddy = mkCandidate {
+      name = "caddy";
+      upstream = pkgs.caddy;
+      subPackages = [ "./cmd/caddy" ];
+      tags = [
+        "nobadger"
+        "nomysql"
+        "nopgx"
+      ];
+    };
+
+    fzf = mkCandidate {
+      name = "fzf";
+      upstream = pkgs.fzf;
+      subPackages = [ "." ];
+    };
+  };
+
+  guestCheck = vm-test.vmTest {
+    name = "go-ecosystem";
+    initramfs = vm-test.mkInitramfs {
+      name = "go-ecosystem";
+      init = ./guest-test.sh;
+      contents = [ busybox ] ++ lib.attrValues tests ++ lib.attrValues candidates;
+    };
+  };
+in
+{
+  inherit candidates tests;
+  package =
+    (pkgs.linkFarm "go-ecosystem-tests" (
+      lib.mapAttrsToList (name: path: {
+        name = "test-${name}";
+        inherit path;
+      }) tests
+      ++ lib.mapAttrsToList (name: path: {
+        name = "candidate-${name}";
+        inherit path;
+      }) candidates
+    )).overrideAttrs
+      (_: {
+        passthru.checks.guest = guestCheck;
+      });
+  recurseForDerivations = true;
+}


### PR DESCRIPTION
Stacked on #128.

## What changed

- add a nixpkgs-style compatibility source set for `golang.org/x/sys`, `x/term`, `x/net`, and `x/crypto`
- generate the Linux/wasm `x/sys/unix` types and syscall wrappers from the distro sysroot while preserving Go's 64-bit-pointer / kernel ILP32 split ABI
- build `go test -c` outputs for selected library and application packages
- build CGO-disabled yq, age, restic, Caddy, and fzf candidates from nixpkgs-pinned sources and vendor hashes
- boot all test binaries and candidates in one initramfs, run a documented positive test matrix, and smoke each CLI

## Why

Compiling a hello-world program does not exercise the compatibility surface used by real Go software. This gives the Go port a reproducible ecosystem gate and keeps source/version/vendor provenance native to nixpkgs.

The guest deliberately uses one vCPU. Two-vCPU trials exposed intermittent Go split-stack corruption in larger test functions; that is a runtime follow-up rather than something this compatibility layer should hide. Tests requiring IPv6 loopback, source-tree fixtures, unsupported mmap/vectored-I/O/epoll/time syscalls, or production-cost password KDF work are narrowed and documented in the guest script.

## Validation

- `nix build -L --no-link .#go-compat .#go-ecosystem`
- `nix flake check --no-build`
- `nix build -L --no-link .#checks.x86_64-linux.go-ecosystem-package-check-guest`

The guest passes the selected x/sys, x/term, x/net, x/crypto, yq, age, restic, Caddy, and fzf tests, followed by CLI smokes for all five applications.