### PR TITLE
linux-guest: format the virtiofs sources with oxfmt

### DIFF
--- a/packages/linux-guest/src/browser.ts
+++ b/packages/linux-guest/src/browser.ts
@@ -326,12 +326,7 @@ export class BrowserFS implements FS<Node, Handle> {
     return new Handle(current);
   }
 
-  async create(
-    parent: Node,
-    name: string,
-    flags: number,
-    context: FSCreateContext,
-  ) {
+  async create(parent: Node, name: string, flags: number, context: FSCreateContext) {
     name = valid_name(name);
     const parent_node = this.#as_node(parent);
     const directory = this.#directory(parent);
@@ -355,12 +350,7 @@ export class BrowserFS implements FS<Node, Handle> {
     return { node, handle: new Handle(node) };
   }
 
-  async read(
-    node: Node,
-    handle: Handle,
-    offset: bigint,
-    length: number,
-  ) {
+  async read(node: Node, handle: Handle, offset: bigint, length: number) {
     const current = this.#open_handle(node, handle);
     if (current.handle.kind !== "file") {
       throw new FSError("EISDIR");
@@ -374,12 +364,7 @@ export class BrowserFS implements FS<Node, Handle> {
     );
   }
 
-  async write(
-    node: Node,
-    handle: Handle,
-    offset: bigint,
-    data: Uint8Array,
-  ) {
+  async write(node: Node, handle: Handle, offset: bigint, data: Uint8Array) {
     const current = this.#open_handle(node, handle);
     return await this.#mutate(current, async () => {
       this.#open_handle(node, handle);
@@ -417,10 +402,7 @@ export class BrowserFS implements FS<Node, Handle> {
     return new Handle(this.#as_node(node));
   }
 
-  async readdir(
-    node: Node,
-    handle: Handle,
-  ): Promise<FSDirectoryEntry<Node>[]> {
+  async readdir(node: Node, handle: Handle): Promise<FSDirectoryEntry<Node>[]> {
     const current = this.#open_handle(node, handle);
     const result: FSDirectoryEntry<Node>[] = [];
     for await (const [name, handle] of this.#directory(node).entries()) {
@@ -491,12 +473,7 @@ export class BrowserFS implements FS<Node, Handle> {
     return output;
   }
 
-  async rename(
-    oldParent: Node,
-    oldName: string,
-    newParent: Node,
-    newName: string,
-  ) {
+  async rename(oldParent: Node, oldName: string, newParent: Node, newName: string) {
     oldName = valid_name(oldName);
     newName = valid_name(newName);
     const old_parent = this.#as_node(oldParent);

--- a/packages/linux-guest/src/node.ts
+++ b/packages/linux-guest/src/node.ts
@@ -53,10 +53,7 @@ function filesystem_error(error: unknown): never {
   if (error instanceof FSError) throw error;
   const code = (error as NodeJS.ErrnoException)?.code;
   if (code && known_errors.has(code)) {
-    throw new FSError(
-      code as ConstructorParameters<typeof FSError>[0],
-      (error as Error).message,
-    );
+    throw new FSError(code as ConstructorParameters<typeof FSError>[0], (error as Error).message);
   }
   throw new FSError("EIO", error instanceof Error ? error.message : String(error));
 }
@@ -190,10 +187,7 @@ function translate_open_flags(flags: number) {
     throw new FSError("EOPNOTSUPP", "unsupported Linux open mode");
   }
   if (remaining !== 0) {
-    throw new FSError(
-      "EINVAL",
-      `unsupported Linux open flags 0x${remaining.toString(16)}`,
-    );
+    throw new FSError("EINVAL", `unsupported Linux open flags 0x${remaining.toString(16)}`);
   }
   return result;
 }
@@ -340,10 +334,7 @@ export class NodeFS implements FS<Node, Handle> {
         await this.#stats(node);
         return node;
       } catch (error) {
-        if (
-          error instanceof FSError &&
-          (error as { readonly errno: number }).errno === 2
-        ) {
+        if (error instanceof FSError && (error as { readonly errno: number }).errno === 2) {
           this.#forget(parts);
           return undefined;
         }
@@ -365,12 +356,7 @@ export class NodeFS implements FS<Node, Handle> {
     );
   }
 
-  async symlink(
-    parent: Node,
-    name: string,
-    target: string,
-    _context: FSCreateContext,
-  ) {
+  async symlink(parent: Node, name: string, target: string, _context: FSCreateContext) {
     this.#writable();
     return await this.#path_operation(async () => {
       const parts = [...this.#parts(parent), valid_name(name)];
@@ -379,11 +365,7 @@ export class NodeFS implements FS<Node, Handle> {
     });
   }
 
-  async #setattr(
-    node: Node,
-    changes: FSSetAttributes,
-    file?: FileHandle,
-  ) {
+  async #setattr(node: Node, changes: FSSetAttributes, file?: FileHandle) {
     const target = file ? undefined : await this.#validated_path(this.#parts(node));
     const current = async () =>
       file ? await node_call(file.stat({ bigint: true })) : await this.#stats(node);
@@ -435,11 +417,7 @@ export class NodeFS implements FS<Node, Handle> {
     }
   }
 
-  async setattr(
-    node: Node,
-    changes: FSSetAttributes,
-    handle?: Handle,
-  ) {
+  async setattr(node: Node, changes: FSSetAttributes, handle?: Handle) {
     this.#writable();
     if (handle instanceof Handle && handle.file) {
       return await this.#setattr(node, changes, handle.file);
@@ -456,12 +434,7 @@ export class NodeFS implements FS<Node, Handle> {
     });
   }
 
-  async create(
-    parent: Node,
-    name: string,
-    flags: number,
-    context: FSCreateContext,
-  ) {
+  async create(parent: Node, name: string, flags: number, context: FSCreateContext) {
     this.#writable();
     const host_flags =
       translate_open_flags(flags | linux_open.create) | constants.O_CREAT | constants.O_NOFOLLOW;
@@ -473,12 +446,7 @@ export class NodeFS implements FS<Node, Handle> {
     });
   }
 
-  async read(
-    _node: Node,
-    handle: Handle,
-    offset: bigint,
-    length: number,
-  ) {
+  async read(_node: Node, handle: Handle, offset: bigint, length: number) {
     if (!(handle instanceof Handle) || !handle.file) {
       throw new FSError("EBADF");
     }
@@ -489,12 +457,7 @@ export class NodeFS implements FS<Node, Handle> {
     return buffer.subarray(0, bytesRead);
   }
 
-  async write(
-    _node: Node,
-    handle: Handle,
-    offset: bigint,
-    data: Uint8Array,
-  ) {
+  async write(_node: Node, handle: Handle, offset: bigint, data: Uint8Array) {
     this.#writable();
     if (!(handle instanceof Handle) || !handle.file) {
       throw new FSError("EBADF");
@@ -534,10 +497,7 @@ export class NodeFS implements FS<Node, Handle> {
     });
   }
 
-  async readdir(
-    node: Node,
-    _handle: Handle,
-  ): Promise<FSDirectoryEntry<Node>[]> {
+  async readdir(node: Node, _handle: Handle): Promise<FSDirectoryEntry<Node>[]> {
     return await this.#path_operation(async () => {
       const parts = this.#parts(node);
       const target = await this.#validated_path(parts);
@@ -585,12 +545,7 @@ export class NodeFS implements FS<Node, Handle> {
     });
   }
 
-  async rename(
-    oldParent: Node,
-    oldName: string,
-    newParent: Node,
-    newName: string,
-  ) {
+  async rename(oldParent: Node, oldName: string, newParent: Node, newName: string) {
     this.#writable();
     await this.#path_operation(async () => {
       const old_parts = [...this.#parts(oldParent), valid_name(oldName)];

--- a/packages/linux-guest/tests/virtio-fs-node.test.ts
+++ b/packages/linux-guest/tests/virtio-fs-node.test.ts
@@ -207,10 +207,7 @@ test("node virtio-fs adapter enforces read-only shares in the backend", async ()
       }),
     () => filesystem.unlink!(filesystem.root, name),
   ]) {
-    await assert.rejects(
-      operation,
-      (error) => error instanceof FSError && error.errno === 30,
-    );
+    await assert.rejects(operation, (error) => error instanceof FSError && error.errno === 30);
   }
   await filesystem.release!(node, handle);
   assert.equal(await readFile(path.join(shared, name), "utf8"), "readable");

--- a/packages/linux-guest/tests/virtio-fs.test.ts
+++ b/packages/linux-guest/tests/virtio-fs.test.ts
@@ -97,12 +97,7 @@ class MemoryFileSystem implements FS<MemoryNode, MemoryHandle> {
     return new MemoryHandle(current);
   }
 
-  create(
-    parent: MemoryNode,
-    name: string,
-    _flags: number,
-    context: FSCreateContext,
-  ) {
+  create(parent: MemoryNode, name: string, _flags: number, context: FSCreateContext) {
     const directory = this.#directory(parent);
     if (directory.children.has(name)) throw new FSError("EEXIST");
     const node = new MemoryNode("file", context.mode);
@@ -110,22 +105,12 @@ class MemoryFileSystem implements FS<MemoryNode, MemoryHandle> {
     return { node, handle: new MemoryHandle(node) };
   }
 
-  read(
-    node: MemoryNode,
-    _handle: MemoryHandle,
-    offset: bigint,
-    length: number,
-  ) {
+  read(node: MemoryNode, _handle: MemoryHandle, offset: bigint, length: number) {
     const current = this.#node(node);
     return current.data.slice(Number(offset), Number(offset) + length);
   }
 
-  write(
-    node: MemoryNode,
-    _handle: MemoryHandle,
-    offset: bigint,
-    data: Uint8Array,
-  ) {
+  write(node: MemoryNode, _handle: MemoryHandle, offset: bigint, data: Uint8Array) {
     const current = this.#node(node);
     const start = Number(offset);
     if (start + data.byteLength > current.data.byteLength) {
@@ -195,12 +180,7 @@ class MemoryFileSystem implements FS<MemoryNode, MemoryHandle> {
     directory.children.delete(name);
   }
 
-  rename(
-    oldParent: MemoryNode,
-    oldName: string,
-    newParent: MemoryNode,
-    newName: string,
-  ) {
+  rename(oldParent: MemoryNode, oldName: string, newParent: MemoryNode, newName: string) {
     const old_directory = this.#directory(oldParent);
     const node = old_directory.children.get(oldName);
     if (!node) throw new FSError("ENOENT");
@@ -211,9 +191,7 @@ class MemoryFileSystem implements FS<MemoryNode, MemoryHandle> {
 
 guest_test("virtio-fs", async (_t, fixture) => {
   const backend = new MemoryFileSystem();
-  const guest = await fixture.spawn([
-    fileSystemDevice(backend, { tag: "test", cache: false }),
-  ]);
+  const guest = await fixture.spawn([fileSystemDevice(backend, { tag: "test", cache: false })]);
   const mounted = await guest.exec([
     "sh",
     "-c",


### PR DESCRIPTION
Fixes main's red CI: `checks/formatting` rewrites four files committed in #132. They were committed in a state that neither oxfmt nor the sandboxed treefmt accepts.

Root cause of the earlier confusion: treefmt's built-in `deno` formatter shadows oxfmt for `*.ts` when `deno` happens to be on PATH (my shell has it; the nix sandbox does not), so local `nix fmt` output differed from the check. These files are formatted with oxfmt directly, which is what the sandbox check enforces.

Note: `nix fmt` from a shell with deno on PATH may still diverge from CI for `*.ts` files; the sandbox is authoritative.