### PR TITLE
runner: test console input queued before boot

### DIFF
--- a/packages/linux/package.nix
+++ b/packages/linux/package.nix
@@ -9,8 +9,10 @@
   src ? pkgs.fetchFromGitHub {
     owner = "tombl";
     repo = "linux";
-    rev = "73c98b7acaaaeba4107d047956db7317615019de";
-    hash = "sha256-hzRcmf5UypPSO5BAqidbPbwpeN0UM+KOlJ2K0p9vfis=";
+    # Temporary review pin for tombl/linux#44. Replace this with the wasm
+    # commit containing tombl/linux#43 and #44 after both PRs merge.
+    rev = "e0786820a2a166245b35ba09509b608c3d8ca1a9";
+    hash = "sha256-uW2IcOTsoiM9a+L7KdCZ5h0A8k5yRWM31Vc5hTsA4nw=";
   },
 }:
 

--- a/packages/linux/package.nix
+++ b/packages/linux/package.nix
@@ -9,10 +9,8 @@
   src ? pkgs.fetchFromGitHub {
     owner = "tombl";
     repo = "linux";
-    # Temporary review pin for tombl/linux#44. Replace this with the wasm
-    # commit containing tombl/linux#43 and #44 after both PRs merge.
-    rev = "e0786820a2a166245b35ba09509b608c3d8ca1a9";
-    hash = "sha256-uW2IcOTsoiM9a+L7KdCZ5h0A8k5yRWM31Vc5hTsA4nw=";
+    rev = "c72012cff129fde0f15a750fdca89b4ea7f9c159";
+    hash = "sha256-oWBSe3niW/riAu+z9tVgFALRca60I5zoUCMXhROvY48=";
   },
 }:
 

--- a/packages/runner/package.nix
+++ b/packages/runner/package.nix
@@ -16,6 +16,12 @@ let
     contents = [ busybox ];
   };
 
+  console-initramfs = vm-test.mkInitramfs {
+    name = "linux-runner-console";
+    init = ./tests/console-init.sh;
+    contents = [ busybox ];
+  };
+
   app = pkgs.stdenvNoCC.mkDerivation {
     pname = "runner-app";
     version = "0.0.0";
@@ -101,6 +107,7 @@ let
       ln -s ${linux-guest.package} packages/runner/node_modules/@tombl/linux-guest
       pnpm --filter=@tombl/linux-runner check
       LINUX_RUNNER_TEST_RUNNER=${package}/bin/wasm-linux-runner \
+        LINUX_RUNNER_TEST_CONSOLE_INITRAMFS=${console-initramfs} \
         LINUX_RUNNER_TEST_LIFECYCLE_INITRAMFS=${lifecycle-initramfs} \
         timeout --kill-after=5 300 pnpm --filter=@tombl/linux-runner test
 

--- a/packages/runner/tests/console-init.sh
+++ b/packages/runner/tests/console-init.sh
@@ -1,0 +1,11 @@
+#!/bin/busybox sh
+
+export PATH=/bin:/sbin
+
+if IFS= read -r input; then
+  printf 'console-input: %s\n' "$input"
+else
+  echo 'console-input: read failed' >&2
+fi
+
+exec /sbin/poweroff -f

--- a/packages/runner/tests/console.test.ts
+++ b/packages/runner/tests/console.test.ts
@@ -1,5 +1,6 @@
+import { consoleDevice, spawnMachine } from "@tombl/linux";
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 function required_environment(name: string): string {
@@ -8,35 +9,36 @@ function required_environment(name: string): string {
   return value;
 }
 
-const runner = required_environment("LINUX_RUNNER_TEST_RUNNER");
+const initramfs = required_environment("LINUX_RUNNER_TEST_CONSOLE_INITRAMFS");
 
-test(
-  "runner preserves console input supplied at launch",
-  { timeout: 45_000 },
-  async (t) => {
-    const child = spawn(runner, ["--cpus", "1"], {
-      signal: t.signal,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    let output = "";
-    child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
-    child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
+function output_sink(output: { text: string }) {
+  const decoder = new TextDecoder();
+  return new WritableStream<Uint8Array>({
+    write(chunk) {
+      output.text += decoder.decode(chunk, { stream: true });
+    },
+    close() {
+      output.text += decoder.decode();
+    },
+  });
+}
 
-    // Keep the expected marker out of the input byte stream so tty echo
-    // cannot make the assertion pass before the shell executes the script.
-    child.stdin.end(
-      "printf '%s%s\\n' LAUNCH_INPUT_ PRESERVED\n/sbin/poweroff -f\n",
-    );
+test("console preserves input queued before boot", { timeout: 45_000 }, async (t) => {
+  const output = { text: "" };
+  const input = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("queued before boot\n"));
+      controller.close();
+    },
+  });
+  const machine = await spawnMachine({
+    cpus: 1,
+    devices: [consoleDevice(input, output_sink(output))],
+    initcpio: readFile(initramfs),
+  });
+  t.after(() => machine.close());
+  void machine.bootConsole.pipeTo(output_sink(output)).catch(() => {});
 
-    const result = await new Promise<{
-      code: number | null;
-      signal: NodeJS.Signals | null;
-    }>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("close", (code, signal) => resolve({ code, signal }));
-    });
-
-    assert.deepEqual(result, { code: 0, signal: null }, output);
-    assert.match(output, /LAUNCH_INPUT_PRESERVED/);
-  },
-);
+  await machine.closed;
+  assert.match(output.text, /console-input: queued before boot/, output.text);
+});

--- a/packages/runner/tests/console.test.ts
+++ b/packages/runner/tests/console.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+function required_environment(name: string): string {
+  const value = process.env[name];
+  assert(value, `${name} is required`);
+  return value;
+}
+
+const runner = required_environment("LINUX_RUNNER_TEST_RUNNER");
+
+test(
+  "runner preserves console input supplied at launch",
+  { timeout: 45_000 },
+  async (t) => {
+    const child = spawn(runner, ["--cpus", "1"], {
+      signal: t.signal,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk: Buffer) => (output += chunk.toString()));
+    child.stderr.on("data", (chunk: Buffer) => (output += chunk.toString()));
+
+    // Keep the expected marker out of the input byte stream so tty echo
+    // cannot make the assertion pass before the shell executes the script.
+    child.stdin.end(
+      "printf '%s%s\\n' LAUNCH_INPUT_ PRESERVED\n/sbin/poweroff -f\n",
+    );
+
+    const result = await new Promise<{
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    }>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    });
+
+    assert.deepEqual(result, { code: 0, signal: null }, output);
+    assert.match(output, /LAUNCH_INPUT_PRESERVED/);
+  },
+);

--- a/packages/runner/tests/shares.test.ts
+++ b/packages/runner/tests/shares.test.ts
@@ -40,9 +40,9 @@ test("runner mounts writable and read-only host shares", async (t) => {
 printf 'from guest\\n' > '/workspace/writable share/guest.txt'
 cat '/workspace/read only/host.txt'
 if printf 'changed\\n' > '/workspace/read only/host.txt'; then
-  echo READ_ONLY_WRITE_SUCCEEDED
+  printf '%s%s\\n' READ_ONLY_WRITE_ SUCCEEDED
 else
-  echo READ_ONLY_ENFORCED
+  printf '%s%s\\n' READ_ONLY_ ENFORCED
 fi
 /sbin/poweroff -f
 `);


### PR DESCRIPTION
## Summary

- pin Linux to the merged `wasm` commit containing tombl/linux#43 and tombl/linux#44
- add an actual-guest regression test that queues console input before machine boot through the JavaScript API
- construct expected share-test markers inside the guest so tty echo cannot produce a false positive

## Kernel changes

The final pin is `c72012cff129fde0f15a750fdca89b4ea7f9c159`, the `wasm` merge commit containing both https://github.com/tombl/linux/pull/43 and https://github.com/tombl/linux/pull/44.

## Why

The old single-port console could deliver host input before Linux opened the console port, losing input queued during guest setup. The multi-port implementation gates delivery on the guest's `PORT_OPEN` notification.

The regression test now exercises that contract directly: it constructs `consoleDevice()` with input already queued in a `ReadableStream`, passes the device to `spawnMachine()`, and boots a purpose-built initramfs that reads and acknowledges the input before powering off. It does not involve the runner executable, child processes, Node stdio adapters, terminal reconfiguration, sleeps, or retries.

## Validation

- direct console integration test against the merged kernel: 1/1 passed
- `pnpm --filter=@tombl/linux-guest build`
- `pnpm --filter=@tombl/linux-runner check`
- `nix flake check --no-build`
- `nix build .#linux --no-link` from the final merged pin
- 60/60 four-vCPU lifecycle stress runs without a RuntimeError

The full GitHub build has been retriggered for the updated test.
