### PR TITLE
linux: preserve early initramfs console output

### DIFF
--- a/packages/linux/package.nix
+++ b/packages/linux/package.nix
@@ -9,8 +9,8 @@
   src ? pkgs.fetchFromGitHub {
     owner = "tombl";
     repo = "linux";
-    rev = "c72012cff129fde0f15a750fdca89b4ea7f9c159";
-    hash = "sha256-oWBSe3niW/riAu+z9tVgFALRca60I5zoUCMXhROvY48=";
+    rev = "f2ca017b44770e5dcd93342099c524b004b5818f";
+    hash = "sha256-//zdMS0kWntP1h7Ar0PdpJNqvnKa+vg21tbTiyBLHnM=";
   },
 }:
 


### PR DESCRIPTION
<!-- jj-pr stack navigation -->
## Stack
- https://github.com/tombl/distro/pull/142 :point_left:
- https://github.com/tombl/distro/pull/130
- https://github.com/tombl/distro/pull/135
- https://github.com/tombl/distro/pull/136
<!-- /jj-pr stack navigation -->