### PR TITLE
packages: fix merged CI failures

### DIFF
--- a/distro/curl/package.nix
+++ b/distro/curl/package.nix
@@ -61,7 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     # but curl-config and the development metadata describe the guest runtime.
     # Translate those two known build roots to / so downstream guest builds do
     # not claim that their Nix locations will exist after APK installation.
-    substituteInPlace "$out/bin/curl-config" "$out/lib/libcurl.la" \
+    substituteInPlace "$out/bin/curl-config" \
+      --replace-fail ${openssl} / \
+      --replace-fail ${zlib} /
+    substituteInPlace "$out/lib/libcurl.la" \
       --replace-fail ${openssl} / \
       --replace-fail ${zlib} /
     substituteInPlace "$out/lib/pkgconfig/libcurl.pc" \

--- a/distro/file/package.nix
+++ b/distro/file/package.nix
@@ -29,10 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     "pkgdatadir=/usr/share/misc"
   ];
 
-  # Keep the compiled guest path above, but stage the database under $out so
-  # the APK installs it at /usr/share/misc.
-  installFlags = [ "pkgdatadir=$(out)/usr/share/misc" ];
-
   configureFlags = [
     "--disable-shared"
     "--enable-static"


### PR DESCRIPTION
Fixes the two failures observed after merging #144.

- Split curl metadata substitutions by file. `substituteInPlace` applies every replacement to every named file, but `curl-config` and `libcurl.la` do not contain identical references; the prior combined invocation therefore failed even though each embedded OpenSSL/zlib path is still treated strictly.
- Let the shared `DESTDIR=$out` staging contract place file's magic database. Passing `pkgdatadir=$(out)/usr/share/misc` as an install flag duplicated the output path beneath itself, so `/usr/share/misc/magic.mgc` was absent in the guest.

Local validation:

- `nix build .#curl .#file -L`
- verified `file` contains `/usr/share/misc/magic.mgc`, has no nested `$out/nix`, and neither package output embeds a Nix store path
- `nix build .#checks.x86_64-linux.curl-check-transfers .#checks.x86_64-linux.file-check-detect -L`
- `nix flake check -L`
- `nix fmt -- --ci`
- `git diff --check`