### PR TITLE
kernel: support virtio devices in workers

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -93,6 +93,7 @@
         blockDevice,
         spawnGuest,
       } from "@tombl/linux-guest";
+      import { workerDevice } from "@lowland/kernel";
       import { BrowserFS } from "@tombl/linux-guest/browser";
       import { serveGuest } from "./static/__ASSET_DIRECTORY__/bridge-client.js";
 
@@ -239,63 +240,35 @@
       async function openInstallDisk({ requireFilesystem }) {
         const directory = await navigator.storage.getDirectory();
         const handle = await directory.getFileHandle("root.ext4", { create: true });
-        let file = await handle.getFile();
-        if (file.size === 0 && !requireFilesystem) {
-          // The browser owns only the persistent block device's capacity. The
-          // live guest owns its filesystem format and label, exactly as an
-          // installer does for a blank physical disk.
-          const writable = await handle.createWritable();
-          await writable.truncate(64 * 1024 * 1024);
-          await writable.close();
-          file = await handle.getFile();
-        }
-
-        const disk = new Uint8Array(await file.arrayBuffer());
-
+        const file = await handle.getFile();
         const superblock = 1024;
         const magicOffset = superblock + 56;
+        const magic = new Uint8Array(await file.slice(magicOffset, magicOffset + 2).arrayBuffer());
         const hasFilesystem =
-          disk.byteLength >= magicOffset + 2 &&
-          disk[magicOffset] === 0x53 &&
-          disk[magicOffset + 1] === 0xef;
+          file.size >= magicOffset + 2 && magic[0] === 0x53 && magic[1] === 0xef;
         if (requireFilesystem && !hasFilesystem) {
           throw new Error("persistent disk is not a valid ext4 image");
         }
         if (!requireFilesystem && hasFilesystem) return undefined;
 
-        const BLOCK = 4096;
-        const dirty = new Set();
-        const storage = {
-          capacity: disk.byteLength,
-          read(offset, target) {
-            const source = disk.subarray(offset, offset + target.byteLength);
-            target.set(source);
-            return source.byteLength;
-          },
-          write(offset, data) {
-            disk.set(data, offset);
-            const first = Math.floor(offset / BLOCK);
-            const last = Math.floor((offset + data.byteLength - 1) / BLOCK);
-            for (let block = first; block <= last; block++) dirty.add(block);
-            return data.byteLength;
-          },
-          async flush() {
-            if (dirty.size === 0) return;
-            const writable = await handle.createWritable({ keepExistingData: true });
-            for (const block of dirty) {
-              const offset = block * BLOCK;
-              await writable.write({
-                type: "write",
-                position: offset,
-                data: disk.slice(offset, offset + Math.min(BLOCK, disk.byteLength - offset)),
-              });
-            }
-            await writable.close();
-            dirty.clear();
-          },
-        };
-
-        return storage;
+        const worker = new Worker("./static/__ASSET_DIRECTORY__/opfs-disk-worker.js", {
+          type: "module",
+        });
+        const devicePromise = workerDevice(worker);
+        worker.postMessage({
+          handle,
+          // The host supplies capacity for a new physical disk; the guest
+          // installer remains solely responsible for its filesystem contents.
+          capacity: file.size === 0 ? 64 * 1024 * 1024 : undefined,
+        });
+        try {
+          const device = await devicePromise;
+          void device.closed.finally(() => worker.terminate()).catch(() => {});
+          return device;
+        } catch (error) {
+          worker.terminate();
+          throw error;
+        }
       }
 
       // The host adapter upgrades the guest's plaintext HTTP request to HTTPS.
@@ -315,7 +288,7 @@
       const opfs = await navigator.storage.getDirectory();
       const bootDirectory = await opfs.getDirectoryHandle("boot", { create: true });
       const guest = await spawnGuest({
-        root: blockDevice(disk),
+        root: bootMode === "live" ? blockDevice(disk) : disk,
         bootConsole: bootOut,
         // One CPU is the supported architecture until SMP is ready to become
         // part of the facade contract.
@@ -324,7 +297,7 @@
         cmdline: `${bootMode === "live" ? "lowland.root.overlay=tmpfs " : ""}${cmdline.replace(/\+/g, " ")}`,
         devices: [
           ttyConsole,
-          ...(installDisk ? [blockDevice(installDisk)] : []),
+          ...(installDisk ? [installDisk] : []),
           entropyDevice(),
           fileSystemDevice(new BrowserFS(bootDirectory), { tag: "boot", cache: false }),
         ],

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -210,25 +210,28 @@
 
         return {
           capacity: size,
-          async read(offset, length) {
+          async read(offset, target) {
+            const length = target.byteLength;
             if (offset < 0 || length < 0 || offset + length > size) {
               throw new RangeError("rootfs read is outside the disk");
             }
-            if (whole) return whole.slice(offset, offset + length);
+            if (whole) {
+              target.set(whole.subarray(offset, offset + length));
+              return length;
+            }
             const first = Math.floor(offset / CHUNK);
             const last = Math.floor((offset + length - 1) / CHUNK);
             const loaded = await Promise.all(
               Array.from({ length: last - first + 1 }, (_, index) => loadChunk(first + index)),
             );
-            const result = new Uint8Array(length);
             for (let index = 0; index < loaded.length; index++) {
               const chunkIndex = first + index;
               const chunkStart = chunkIndex * CHUNK;
               const from = Math.max(offset, chunkStart);
               const to = Math.min(offset + length, chunkStart + loaded[index].byteLength);
-              result.set(loaded[index].subarray(from - chunkStart, to - chunkStart), from - offset);
+              target.set(loaded[index].subarray(from - chunkStart, to - chunkStart), from - offset);
             }
-            return result;
+            return length;
           },
         };
       }
@@ -264,8 +267,10 @@
         const dirty = new Set();
         const storage = {
           capacity: disk.byteLength,
-          read(offset, length) {
-            return disk.slice(offset, offset + length);
+          read(offset, target) {
+            const source = disk.subarray(offset, offset + target.byteLength);
+            target.set(source);
+            return source.byteLength;
           },
           write(offset, data) {
             disk.set(data, offset);

--- a/apps/site/opfs-disk-worker.js
+++ b/apps/site/opfs-disk-worker.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+import { blockDevice } from "@lowland/kernel/virtio/block.js";
+import { serveDevice } from "@lowland/kernel/virtio/remote.js";
+
+const configuration = await new Promise((resolve) =>
+  addEventListener("message", (event) => resolve(event.data), { once: true }),
+);
+
+async function openAccessHandle(handle) {
+  // A navigation may start the replacement worker while the old page's worker
+  // is still releasing its exclusive OPFS lock. Retry only that lock conflict;
+  // every other initialization error must remain visible to workerDevice().
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await handle.createSyncAccessHandle();
+    } catch (error) {
+      if (error?.name !== "NoModificationAllowedError" || attempt === 7) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 10 * 2 ** attempt));
+    }
+  }
+}
+
+const access = await openAccessHandle(configuration.handle);
+if (configuration.capacity !== undefined) access.truncate(configuration.capacity);
+const capacity = access.getSize();
+
+serveDevice(
+  self,
+  blockDevice({
+    capacity,
+    read(offset, target) {
+      let read = 0;
+      while (read < target.byteLength) {
+        const n = access.read(target.subarray(read), { at: offset + read });
+        if (n === 0) break;
+        read += n;
+      }
+      return read;
+    },
+    write(offset, data) {
+      let written = 0;
+      while (written < data.byteLength) {
+        const n = access.write(data.subarray(written), { at: offset + written });
+        if (n === 0) break;
+        written += n;
+      }
+      return written;
+    },
+    flush() {
+      access.flush();
+    },
+    close() {
+      try {
+        access.flush();
+      } finally {
+        access.close();
+      }
+    },
+  }),
+);

--- a/distro/npm/browser-tests.nix
+++ b/distro/npm/browser-tests.nix
@@ -21,12 +21,14 @@ let
     cp ${source}/app.js $out/app.js
     cp ${source}/index.html $out/index.html
     cp ${source}/playwright.config.js $out/playwright.config.js
+    cp ${site.package}/static/*/opfs-disk-worker.js $out/opfs-disk-worker.js
     cp ${basic-init.schedulerHandoffInitramfs} $out/scheduler-handoff.cpio
     cp ${basic-init.remoteMemoryInitramfs} $out/remote-vm.cpio
     cp ${source}/server.js $out/server.js
     cp ${linux-guest.package.checks.tests.assets}/rootfs.erofs $out/rootfs.erofs
     mkdir $out/tests
     cp ${source}/tests/boot.spec.js $out/tests/
+    cp ${source}/tests/opfs-disk.spec.js $out/tests/
     cp ${source}/tests/remote-memory.spec.js $out/tests/
     cp ${source}/tests/spawn-stress.spec.js $out/tests/
     cp ${source}/tests/virtio-fs.spec.js $out/tests/

--- a/distro/npm/runner/package.nix
+++ b/distro/npm/runner/package.nix
@@ -70,6 +70,7 @@ let
 
       mkdir -p $out/node_modules/@lowland/bytes $out/node_modules/@tombl
       cp packages/runner/src/run.ts $out/run.ts
+      cp packages/runner/src/disk-worker.ts $out/disk-worker.ts
       cp packages/runner/src/shares.ts $out/shares.ts
       cp packages/runner/package.json $out/package.json
       cp -RL ${bytes}/. $out/node_modules/@lowland/bytes/
@@ -123,6 +124,7 @@ let
       LINUX_RUNNER_TEST_RUNNER=${package}/bin/wasm-linux-runner \
         LINUX_RUNNER_TEST_CONSOLE_INITRAMFS=${console-initramfs} \
         LINUX_RUNNER_TEST_LIFECYCLE_DISK=${lifecycle-rootfs} \
+        LINUX_RUNNER_TEST_ROOT_DISK=${rootfs} \
         timeout --kill-after=5 300 pnpm --filter=@tombl/linux-runner test
 
       runHook postBuild

--- a/distro/site/assets.nix
+++ b/distro/site/assets.nix
@@ -4,6 +4,7 @@
   pkgs,
   kernel,
   linux-guest,
+  opfsDiskWorker,
 }:
 
 pkgs.runCommand "site-assets" { } ''
@@ -16,4 +17,5 @@ pkgs.runCommand "site-assets" { } ''
   cp -rL ${linux-guest.package}/dist $out/guest
   cp -L ${linux-guest.package}/agent.erofs $out/agent.erofs
   cp ${bridge-site.package.client} $out/bridge-client.js
+  cp ${opfsDiskWorker}/opfs-disk-worker.js $out/opfs-disk-worker.js
 ''

--- a/distro/site/default.nix
+++ b/distro/site/default.nix
@@ -1,7 +1,8 @@
 { callPackage }:
 
 rec {
-  assets = callPackage ./assets.nix { };
+  opfsDiskWorker = callPackage ./opfs-disk-worker.nix { };
+  assets = callPackage ./assets.nix { inherit opfsDiskWorker; };
   liveFiles = callPackage ./files.nix {
     inherit assets;
     bootMode = "live";

--- a/distro/site/opfs-disk-worker.nix
+++ b/distro/site/opfs-disk-worker.nix
@@ -1,0 +1,24 @@
+{
+  bytes,
+  kernel,
+  pkgs,
+}:
+
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "opfs-disk-worker";
+  version = "0.0.0";
+  dontUnpack = true;
+  nativeBuildInputs = [ pkgs.esbuild ];
+
+  installPhase = ''
+    mkdir -p node_modules/@lowland $out
+    ln -s ${bytes} node_modules/@lowland/bytes
+    esbuild ${../../apps/site/opfs-disk-worker.js} \
+      --bundle \
+      --format=esm \
+      --minify \
+      --alias:@lowland/kernel/virtio/block.js=${kernel}/dist/virtio/block.js \
+      --alias:@lowland/kernel/virtio/remote.js=${kernel}/dist/virtio/remote.js \
+      --outfile=$out/opfs-disk-worker.js
+  '';
+}

--- a/distro/vm-test/run-test.js
+++ b/distro/vm-test/run-test.js
@@ -151,15 +151,14 @@ if (diskPath) {
   devices.push(
     blockDevice({
       capacity: size,
-      read: async (offset, length) => {
-        const data = new Uint8Array(length);
+      read: async (offset, data) => {
         let read = 0;
         while (read < data.length) {
           const length = readSync(disk, data, read, data.length - read, offset + read);
           if (length === 0) break;
           read += length;
         }
-        return data.subarray(0, read);
+        return read;
       },
       write: async (offset, data) => {
         let written = 0;

--- a/packages/bridge-site/tests/vm.html
+++ b/packages/bridge-site/tests/vm.html
@@ -58,8 +58,9 @@
     const rootfs = await bytes("/rootfs.erofs");
     const root = blockDevice({
       capacity: rootfs.byteLength,
-      read(offset, length) {
-        return rootfs.subarray(offset, offset + length);
+      read(offset, target) {
+        target.set(rootfs.subarray(offset, offset + target.byteLength));
+        return target.byteLength;
       },
     });
     const guest = await spawnGuest({

--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -106,7 +106,7 @@ globalThis.opfsWorkerDiskRoundTrip = async () => {
     );
     return { marker, write, read };
   } finally {
-    await directory.removeEntry(name).catch(() => {});
+    await directory.removeEntry(name);
   }
 };
 

--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -20,8 +20,10 @@ async function rootDevice() {
   const bytes = await rootfs;
   return blockDevice({
     capacity: bytes.byteLength,
-    read(offset, length) {
-      return bytes.subarray(offset, offset + length);
+    read(offset, target) {
+      const source = bytes.subarray(offset, offset + target.byteLength);
+      target.set(source);
+      return source.byteLength;
     },
   });
 }

--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -1,4 +1,10 @@
-import { blockDevice, bootMachine, consoleDevice, fileSystemDevice } from "@lowland/kernel";
+import {
+  blockDevice,
+  bootMachine,
+  consoleDevice,
+  fileSystemDevice,
+  workerDevice,
+} from "@lowland/kernel";
 import { spawnGuest } from "@tombl/linux-guest";
 import { BrowserFS } from "@tombl/linux-guest/browser";
 
@@ -28,6 +34,23 @@ async function rootDevice() {
   });
 }
 
+async function opfsDiskDevice(handle, capacity) {
+  const worker = new Worker("/opfs-disk-worker.js", { type: "module" });
+  const devicePromise = workerDevice(worker);
+  worker.postMessage({
+    handle,
+    capacity,
+  });
+  try {
+    const device = await devicePromise;
+    void device.closed.finally(() => worker.terminate()).catch(() => {});
+    return device;
+  } catch (error) {
+    worker.terminate();
+    throw error;
+  }
+}
+
 // Boots a guest, runs the scenario, and always shuts the machine down.
 // Scenarios return plain JSON so specs assert on the result directly.
 async function withGuest(scenario, options) {
@@ -45,6 +68,47 @@ globalThis.bootSmoke = () =>
     const result = await collectProcess(await guest.exec(["uname", "-a"]));
     return { ...result, machineClosed: true };
   });
+
+globalThis.opfsWorkerDiskRoundTrip = async () => {
+  const directory = await navigator.storage.getDirectory();
+  const name = "virtio-worker-round-trip.img";
+  await directory.removeEntry(name).catch((error) => {
+    if (error.name !== "NotFoundError") throw error;
+  });
+  const handle = await directory.getFileHandle(name, { create: true });
+  const marker = "opfs-worker-virtio-round-trip";
+
+  try {
+    const first = await opfsDiskDevice(handle, 1024 * 1024);
+    const write = await withGuest(
+      async (guest) =>
+        collectProcess(
+          await guest.exec([
+            "sh",
+            "-c",
+            `until [ -b /dev/vdb ]; do sleep 0.1; done; printf '%s\\n' '${marker}' | dd of=/dev/vdb bs=512 conv=fsync 2>/dev/null`,
+          ]),
+        ),
+      { devices: [first] },
+    );
+
+    const second = await opfsDiskDevice(handle);
+    const read = await withGuest(
+      async (guest) =>
+        collectProcess(
+          await guest.exec([
+            "sh",
+            "-c",
+            "until [ -b /dev/vdb ]; do sleep 0.1; done; dd if=/dev/vdb bs=512 count=1 2>/dev/null | head -n 1",
+          ]),
+        ),
+      { devices: [second] },
+    );
+    return { marker, write, read };
+  } finally {
+    await directory.removeEntry(name).catch(() => {});
+  }
+};
 
 globalThis.spawnStress = () =>
   withGuest(async (guest) => {

--- a/packages/browser-tests/tests/opfs-disk.spec.js
+++ b/packages/browser-tests/tests/opfs-disk.spec.js
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+test("persists a virtio block device through an OPFS worker", async ({ page }) => {
+  page.on("console", (message) => console.log(`[browser] ${message.text()}`));
+  page.on("pageerror", (error) => console.error(`[browser] ${error.stack ?? error}`));
+
+  await page.goto("/");
+  test.skip(
+    !(await page.evaluate(() => "storage" in navigator && "getDirectory" in navigator.storage)),
+    "browser does not expose OPFS",
+  );
+  await expect
+    .poll(() => page.evaluate(() => typeof globalThis.opfsWorkerDiskRoundTrip))
+    .toBe("function");
+  const result = await page.evaluate(() => globalThis.opfsWorkerDiskRoundTrip());
+
+  expect(result.write.status).toEqual({ code: 0, signal: null, success: true });
+  expect(result.write.stderr).toBe("");
+  expect(result.read.status).toEqual({ code: 0, signal: null, success: true });
+  expect(result.read.stderr).toBe("");
+  expect(result.read.stdout).toContain(result.marker);
+});

--- a/packages/kernel/src/endpoint.ts
+++ b/packages/kernel/src/endpoint.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+
+interface EventEndpoint {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  addEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+  addEventListener(type: "messageerror", listener: (event: MessageEvent) => void): void;
+  addEventListener(type: "error", listener: (event: ErrorEvent) => void): void;
+  removeEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: "messageerror", listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: "error", listener: (event: ErrorEvent) => void): void;
+  start?(): void;
+}
+
+export interface EmitterEndpoint {
+  postMessage(message: unknown): void;
+  on(type: "message", listener: (message: unknown) => void): void;
+  on(type: "messageerror", listener: (error: Error) => void): void;
+  on(type: "error", listener: (error: Error) => void): void;
+  off(type: "message", listener: (message: unknown) => void): void;
+  off(type: "messageerror", listener: (error: Error) => void): void;
+  off(type: "error", listener: (error: Error) => void): void;
+  start?(): void;
+}
+
+/** A browser Worker, MessagePort, or Node worker used for bidirectional messages. */
+export type Endpoint = EventEndpoint | EmitterEndpoint;
+
+/** @internal */
+export interface EndpointHandlers {
+  message(message: unknown): void;
+  error?(error: Error): void;
+}
+
+const as_error = (value: unknown, fallback: string) =>
+  value instanceof Error ? value : new Error(fallback);
+
+/** @internal */
+export function listen_endpoint(endpoint: Endpoint, handlers: EndpointHandlers) {
+  if ("addEventListener" in endpoint) {
+    const on_message = (event: MessageEvent) => handlers.message(event.data);
+    const on_message_error = (_event: MessageEvent) =>
+      handlers.error?.(new Error("could not deserialize endpoint message"));
+    const on_error = (event: ErrorEvent) => {
+      event.preventDefault();
+      handlers.error?.(as_error(event.error, event.message || "worker failed"));
+    };
+    endpoint.addEventListener("message", on_message);
+    if (handlers.error) {
+      endpoint.addEventListener("messageerror", on_message_error);
+      endpoint.addEventListener("error", on_error);
+    }
+    return () => {
+      endpoint.removeEventListener("message", on_message);
+      if (handlers.error) {
+        endpoint.removeEventListener("messageerror", on_message_error);
+        endpoint.removeEventListener("error", on_error);
+      }
+    };
+  }
+
+  const on_message = (message: unknown) => handlers.message(message);
+  const on_message_error = (error: Error) =>
+    handlers.error?.(as_error(error, "could not deserialize endpoint message"));
+  const on_error = (error: Error) => handlers.error?.(as_error(error, "worker failed"));
+  endpoint.on("message", on_message);
+  if (handlers.error) {
+    endpoint.on("messageerror", on_message_error);
+    endpoint.on("error", on_error);
+  }
+  return () => {
+    endpoint.off("message", on_message);
+    if (handlers.error) {
+      endpoint.off("messageerror", on_message_error);
+      endpoint.off("error", on_error);
+    }
+  };
+}
+
+/** @internal */
+export function post_endpoint(
+  endpoint: Endpoint,
+  message: unknown,
+  transfer?: Transferable[],
+) {
+  endpoint.postMessage(message, transfer);
+}

--- a/packages/kernel/src/endpoint.ts
+++ b/packages/kernel/src/endpoint.ts
@@ -77,10 +77,6 @@ export function listen_endpoint(endpoint: Endpoint, handlers: EndpointHandlers) 
 }
 
 /** @internal */
-export function post_endpoint(
-  endpoint: Endpoint,
-  message: unknown,
-  transfer?: Transferable[],
-) {
+export function post_endpoint(endpoint: Endpoint, message: unknown, transfer?: Transferable[]) {
   endpoint.postMessage(message, transfer);
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -97,7 +97,7 @@ export class MachinePanicError extends Error {
   }
 }
 
-const resources = (async () => {
+async function read_resources() {
   const { bytes, module: vmlinux } = await platform.load_wasm(
     new URL("../vmlinux.wasm", import.meta.url),
   );
@@ -133,7 +133,10 @@ const resources = (async () => {
     sections,
     initramfs,
   };
-})();
+}
+
+let resources: ReturnType<typeof read_resources> | undefined;
+const load_resources = () => (resources ??= read_resources());
 
 const PAGE_SIZE = 0x10000;
 // Leave the final wasm32 page out so the physical-memory size fits in u32.
@@ -230,7 +233,7 @@ export async function bootMachine(options: BootMachineOptions): Promise<Machine>
   const close = () => void finish();
 
   try {
-    const { sections, vmlinux, initramfs, memory: memory_type } = await resources;
+    const { sections, vmlinux, initramfs, memory: memory_type } = await load_resources();
     const initcpio = options.initcpio ? await options.initcpio : undefined;
     const module_pages = Number(memory_type.minimum);
     const initcpio_addr = module_pages * PAGE_SIZE;

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -34,6 +34,7 @@ export {
   type VirtqueueHandler,
 } from "./virtio/core.ts";
 export { blockDevice, type BlockDeviceStorage } from "./virtio/block.ts";
+export { type Endpoint, serveDevice, workerDevice } from "./virtio/remote.ts";
 export { type ConsoleDevice, consoleDevice } from "./virtio/console.ts";
 export { entropyDevice } from "./virtio/entropy.ts";
 export {

--- a/packages/kernel/src/platform.ts
+++ b/packages/kernel/src/platform.ts
@@ -4,12 +4,7 @@
 // Selected at runtime by the presence of process.getBuiltinModule, so bundlers
 // only ever see the web path and never try to resolve node builtins.
 
-import {
-  listen_endpoint,
-  post_endpoint,
-  type EmitterEndpoint,
-  type Endpoint,
-} from "./endpoint.ts";
+import { listen_endpoint, post_endpoint, type EmitterEndpoint, type Endpoint } from "./endpoint.ts";
 import { assert } from "./util.ts";
 
 export interface WorkerHandle {

--- a/packages/kernel/src/platform.ts
+++ b/packages/kernel/src/platform.ts
@@ -4,6 +4,12 @@
 // Selected at runtime by the presence of process.getBuiltinModule, so bundlers
 // only ever see the web path and never try to resolve node builtins.
 
+import {
+  listen_endpoint,
+  post_endpoint,
+  type EmitterEndpoint,
+  type Endpoint,
+} from "./endpoint.ts";
 import { assert } from "./util.ts";
 
 export interface WorkerHandle {
@@ -16,20 +22,32 @@ export interface WorkerHandlers {
   on_error(error: Error): void;
 }
 
-/** A worker's connection back to the thread that spawned it. */
-export interface WorkerChannel {
-  post(message: unknown, transfer?: Transferable[]): void;
-  on_message(handler: (message: unknown) => void): void;
-}
-
 interface Platform {
   load_wasm(url: URL): Promise<{
     bytes: Uint8Array<ArrayBuffer>;
     module: WebAssembly.Module;
   }>;
   spawn_worker(name: string, handlers: WorkerHandlers): WorkerHandle;
-  worker_channel(): WorkerChannel;
+  worker_endpoint(): Endpoint;
   quit(): void;
+}
+
+function worker_handle(
+  endpoint: Endpoint,
+  terminate: () => void | Promise<unknown>,
+  handlers: WorkerHandlers,
+): WorkerHandle {
+  const stop_listening = listen_endpoint(endpoint, {
+    message: handlers.on_message,
+    error: handlers.on_error,
+  });
+  return {
+    post: (message, transfer) => post_endpoint(endpoint, message, transfer),
+    terminate: async () => {
+      stop_listening();
+      await terminate();
+    },
+  };
 }
 
 const web: Platform = {
@@ -45,27 +63,10 @@ const web: Platform = {
       type: "module",
       name,
     });
-    worker.onmessage = (event) => handlers.on_message(event.data);
-    worker.onerror = (event) => {
-      event.preventDefault();
-      handlers.on_error(
-        event.error instanceof Error
-          ? event.error
-          : new Error(event.message || "machine worker failed"),
-      );
-    };
-    return {
-      post: (message, transfer) => worker.postMessage(message, transfer ?? []),
-      terminate: async () => worker.terminate(),
-    };
+    return worker_handle(worker, () => worker.terminate(), handlers);
   },
-  worker_channel() {
-    return {
-      post: (message, transfer) => self.postMessage(message, transfer ?? []),
-      on_message: (handler) => {
-        self.onmessage = (event) => handler(event.data);
-      },
-    };
+  worker_endpoint() {
+    return self;
   },
   quit() {
     self.close();
@@ -74,16 +75,8 @@ const web: Platform = {
 
 // Hand-written types for the slices of the node builtins we use, so that
 // @types/node doesn't leak into a web-first package.
-interface NodeWorker {
-  postMessage(message: unknown, transfer?: Transferable[]): void;
+interface NodeWorker extends EmitterEndpoint {
   terminate(): Promise<number>;
-  on(event: "message", handler: (message: unknown) => void): this;
-  on(event: "error", handler: (error: Error) => void): this;
-}
-
-interface NodeParentPort {
-  postMessage(message: unknown, transfer?: Transferable[]): void;
-  on(event: "message", handler: (message: unknown) => void): this;
 }
 
 interface GetBuiltinModule {
@@ -92,7 +85,7 @@ interface GetBuiltinModule {
   };
   (id: "node:worker_threads"): {
     Worker: new (filename: URL, options: { name: string }) => NodeWorker;
-    parentPort: NodeParentPort | null;
+    parentPort: Endpoint | null;
   };
 }
 
@@ -113,19 +106,11 @@ function node(getBuiltinModule: GetBuiltinModule, process: NodeProcess): Platfor
       const worker = new Worker(new URL("./worker.js", import.meta.url), {
         name,
       });
-      worker.on("message", handlers.on_message);
-      worker.on("error", handlers.on_error);
-      return {
-        post: (message, transfer) => worker.postMessage(message, transfer),
-        terminate: async () => void (await worker.terminate()),
-      };
+      return worker_handle(worker, () => worker.terminate(), handlers);
     },
-    worker_channel() {
+    worker_endpoint() {
       assert(parentPort, "not in a worker");
-      return {
-        post: (message, transfer) => parentPort.postMessage(message, transfer),
-        on_message: (handler) => parentPort.on("message", handler),
-      };
+      return parentPort;
     },
     quit() {
       process.exit(0);

--- a/packages/kernel/src/virtio/block.ts
+++ b/packages/kernel/src/virtio/block.ts
@@ -40,6 +40,8 @@ export interface BlockDeviceStorage {
   write?(offset: number, data: Uint8Array): MaybePromise<number>;
   /** Flushes completed writes. Its presence advertises the flush feature. */
   flush?(): MaybePromise<void>;
+  /** Releases storage resources when the device closes. */
+  close?(): MaybePromise<void>;
   /** Total size in bytes. */
   capacity: number;
 }
@@ -140,5 +142,8 @@ export function blockDevice(storage: BlockDeviceStorage): VirtioDevice {
     }
   }
 
-  return new VirtioController({ deviceId: 2, features, config }, { queues: [notify] }).device;
+  return new VirtioController(
+    { deviceId: 2, features, config },
+    { queues: [notify], close: () => storage.close?.() },
+  ).device;
 }

--- a/packages/kernel/src/virtio/block.ts
+++ b/packages/kernel/src/virtio/block.ts
@@ -34,8 +34,8 @@ type MaybePromise<T> = T | Promise<T>;
 
 /** The storage behind a block device. */
 export interface BlockDeviceStorage {
-  /** Returns `length` bytes at `offset`. */
-  read(offset: number, length: number): MaybePromise<Uint8Array>;
+  /** Reads into `target` at `offset`, returning the bytes read. */
+  read(offset: number, target: Uint8Array): MaybePromise<number>;
   /** Writes `data` at `offset`, returning the bytes written. Without it the device is read-only. */
   write?(offset: number, data: Uint8Array): MaybePromise<number>;
   /** Flushes completed writes. Its presence advertises the flush feature. */
@@ -53,7 +53,11 @@ export interface BlockDeviceStorage {
  * ```ts
  * blockDevice({
  *   capacity: rootfs.byteLength,
- *   read: (offset, length) => rootfs.subarray(offset, offset + length),
+ *   read(offset, target) {
+ *     const source = rootfs.subarray(offset, offset + target.byteLength);
+ *     target.set(source);
+ *     return source.byteLength;
+ *   },
  * })
  * ```
  */
@@ -90,14 +94,18 @@ export function blockDevice(storage: BlockDeviceStorage): VirtioDevice {
       let offset = Number(request.sector) * 512;
       switch (request.type) {
         case BlockDeviceRequestType.IN: {
+          let ok = true;
           for (const desc of data) {
             assert(desc.writable, "data must be writable when IN");
-            const arr = await storage.read(offset, desc.array.byteLength);
-            desc.array.set(arr);
-            n += arr.byteLength;
-            offset += arr.byteLength;
+            const read = await storage.read(offset, desc.array);
+            if (read !== desc.array.byteLength) {
+              ok = false;
+              break;
+            }
+            n += read;
+            offset += read;
           }
-          set_status(BlockDeviceStatus.OK);
+          set_status(ok ? BlockDeviceStatus.OK : BlockDeviceStatus.IOERR);
           break;
         }
         case BlockDeviceRequestType.OUT: {

--- a/packages/kernel/src/virtio/core.ts
+++ b/packages/kernel/src/virtio/core.ts
@@ -55,32 +55,34 @@ export interface VirtqueueChain extends Iterable<VirtqueueBuffer> {
 export interface Virtqueue extends Iterable<VirtqueueChain> {}
 
 class Chain implements VirtqueueChain {
-  #buffers: Array<VirtqueueBuffer & { target?: Uint8Array }>;
-  #release: (written: number, commit: () => void) => void;
+  #buffers: Array<VirtqueueBuffer & { address?: number }>;
+  #release: (written: number, outputs: VirtqueueOutput[]) => void;
 
   constructor(
     memory: WebAssembly.Memory,
     desc: Descriptor[],
-    release: (written: number, commit: () => void) => void,
+    release: (written: number, outputs: VirtqueueOutput[]) => void,
   ) {
     this.#buffers = desc.map((descriptor) => {
-      const target = new Uint8Array(memory.buffer, Number(descriptor.addr), descriptor.len);
+      const address = Number(descriptor.addr);
+      const target = new Uint8Array(memory.buffer, address, descriptor.len);
       const writable = (descriptor.flags & DescriptorFlags.WRITE) !== 0;
       // Device work may outlive the queue generation across an await. Keep
       // guest memory isolated until release proves the chain is still valid.
       return writable
-        ? { array: target.slice(), writable, target }
+        ? { array: target.slice(), writable, address }
         : { array: target.slice(), writable };
     });
     this.#release = release;
   }
 
   release(written: number) {
-    this.#release(written, () => {
-      for (const buffer of this.#buffers) {
-        if (buffer.target) buffer.target.set(buffer.array);
-      }
-    });
+    this.#release(
+      written,
+      this.#buffers.flatMap(({ address, array }) =>
+        address === undefined ? [] : [{ address, data: array }],
+      ),
+    );
   }
 
   *[Symbol.iterator]() {
@@ -88,23 +90,62 @@ class Chain implements VirtqueueChain {
   }
 }
 
+export interface VirtqueueOutput {
+  address: number;
+  data: Uint8Array;
+}
+
+export interface VirtqueueCompletion {
+  descriptor_address: number;
+  id: number;
+  written: number;
+  flags: number;
+  outputs: VirtqueueOutput[];
+}
+
+export function publish_virtqueue_completion(
+  memory: WebAssembly.Memory,
+  completion: VirtqueueCompletion,
+) {
+  for (const { address, data } of completion.outputs) {
+    new Uint8Array(memory.buffer, address, data.byteLength).set(data);
+  }
+
+  const descriptor = VirtqDescriptor.get(
+    new DataView(memory.buffer),
+    completion.descriptor_address,
+  );
+  descriptor.id = completion.id;
+  descriptor.len = completion.written;
+  // The flags make the descriptor visible to the guest, so publish them last.
+  descriptor.flags = completion.flags;
+}
+
 class PackedVirtqueue implements Virtqueue {
   #memory: WebAssembly.Memory;
   #size: number;
   #desc_addr: number;
-  #on_release: () => void;
+  #publish: (completion: VirtqueueCompletion) => void;
+  #is_current: () => boolean;
   #avail_wrap = true;
   #used_wrap = true;
   #used_idx = 0;
   #avail_idx = 0;
   #valid = true;
 
-  constructor(memory: WebAssembly.Memory, size: number, desc_addr: number, on_release: () => void) {
+  constructor(
+    memory: WebAssembly.Memory,
+    size: number,
+    desc_addr: number,
+    publish: (completion: VirtqueueCompletion) => void,
+    is_current: () => boolean = () => true,
+  ) {
     assert(size !== 0);
     this.#memory = memory;
     this.#size = size;
     this.#desc_addr = desc_addr;
-    this.#on_release = on_release;
+    this.#publish = publish;
+    this.#is_current = is_current;
   }
 
   invalidate() {
@@ -165,14 +206,18 @@ class PackedVirtqueue implements Virtqueue {
       chain_desc = this.#indirect_descriptors(Number(desc.addr), desc.len / VirtqDescriptor.size);
     }
 
-    return new Chain(this.#memory, chain_desc, (written, commit) =>
-      this.#release(id, skip, written, commit),
+    const chain = new Chain(this.#memory, chain_desc, (written, outputs) =>
+      this.#release(id, skip, written, outputs),
     );
+    // A remote reset can revoke this queue while its descriptors are being
+    // copied. Never expose a mixture of the old and replacement queue to the
+    // device; advancing the stale cursor is harmless because reset replaces it.
+    return this.#is_current() ? chain : null;
   }
 
   *[Symbol.iterator]() {
     let chain;
-    while (this.#valid && (chain = this.#pop())) yield chain;
+    while (this.#valid && this.#is_current() && (chain = this.#pop())) yield chain;
   }
 
   #advance() {
@@ -191,8 +236,8 @@ class PackedVirtqueue implements Virtqueue {
     return index;
   }
 
-  #release(id: number, skip: number, written: number, commit: () => void) {
-    if (!this.#valid) return;
+  #release(id: number, skip: number, written: number, outputs: VirtqueueOutput[]) {
+    if (!this.#valid || !this.#is_current()) return;
 
     const desc = VirtqDescriptor.get(
       new DataView(this.#memory.buffer),
@@ -204,15 +249,17 @@ class PackedVirtqueue implements Virtqueue {
       throw new Error("ring full");
     }
 
-    commit();
-
     let flags = 0;
     if (this.#used_wrap) flags |= DescriptorFlags.AVAIL | DescriptorFlags.USED;
     if (written > 0) flags |= DescriptorFlags.WRITE;
 
-    desc.id = id;
-    desc.len = written;
-    desc.flags = flags;
+    const completion: VirtqueueCompletion = {
+      descriptor_address: this.#desc_addr + VirtqDescriptor.size * this.#used_idx,
+      id,
+      written,
+      flags,
+      outputs,
+    };
 
     this.#used_idx += skip;
     if (this.#used_idx >= this.#size) {
@@ -220,7 +267,7 @@ class PackedVirtqueue implements Virtqueue {
       this.#used_wrap = !this.#used_wrap;
     }
 
-    this.#on_release();
+    this.#publish(completion);
   }
 }
 
@@ -264,13 +311,44 @@ export interface VirtioDriver {
   close?(controller: VirtioController): void | PromiseLike<void>;
 }
 
-interface TransportDevice {
+export interface ConnectedVirtioDevice {
+  set_features(features: bigint): void;
+  setup(config_irq: number, config_address: number, config_length: number): void;
+  enable_queue(
+    vq: number,
+    size: number,
+    descriptor_address: number,
+    irq: number,
+  ): void;
+  disable_queue(vq: number): void;
+  notify(vq: number): void;
+  reset(): void;
+}
+
+export interface VirtioConnectionContext {
+  memory: WebAssembly.Memory;
+  trigger_irq(irq: number): void;
+  on_error(error: unknown): void;
+  // A remote connection replaces only publication. Queue traversal and the
+  // driver remain unchanged, while the main thread retains the final writes
+  // to guest memory. Local connections omit these hooks.
+  publish_completion?(
+    vq: number,
+    irq: number,
+    completion: VirtqueueCompletion,
+  ): void;
+  queue_is_current?(vq: number): boolean;
+  config_target?(length: number): Uint8Array;
+  publish_config?(irq: number, config: Uint8Array, interrupt: boolean): void;
+}
+
+export interface TransportDevice {
   readonly device_id: number;
   readonly features: bigint;
   readonly config: Uint8Array;
-  attach(get_config: () => Uint8Array, raise_config: RaiseConfigInterrupt): void;
-  notify(vq: number, queue: Virtqueue): void | PromiseLike<void>;
-  reset(): void;
+  readonly queues: number;
+  readonly closed: Promise<void>;
+  connect(context: VirtioConnectionContext): ConnectedVirtioDevice;
   close(): Promise<void>;
 }
 
@@ -281,6 +359,19 @@ export interface VirtioDevice extends MachinePluginProvider {
   /** Settles after the device has stopped handling queues and finished cleanup. */
   readonly closed: Promise<void>;
   readonly [transport_device]: TransportDevice;
+}
+
+export function create_virtio_device(endpoint: TransportDevice): VirtioDevice {
+  const device = {} as VirtioDevice;
+  const plugin: MachinePlugin = {
+    configure(setup) {
+      setup.devices.add(device);
+    },
+  };
+  Object.defineProperty(device, transport_device, { value: endpoint });
+  Object.defineProperty(device, getMachinePlugin, { value: () => plugin });
+  Object.defineProperty(device, "closed", { value: endpoint.closed, enumerable: true });
+  return device;
 }
 
 /**
@@ -335,58 +426,58 @@ export class VirtioController {
       return close_completion.promise;
     };
 
+    const features =
+      TransportFeatures.VERSION_1 |
+      TransportFeatures.RING_PACKED |
+      TransportFeatures.INDIRECT_DESC |
+      (options.features ?? 0n);
     const endpoint: TransportDevice = {
       device_id: options.deviceId,
-      features:
-        TransportFeatures.VERSION_1 |
-        TransportFeatures.RING_PACKED |
-        TransportFeatures.INDIRECT_DESC |
-        (options.features ?? 0n),
+      features,
       config,
-
-      attach: (next_get_config, next_raise_config) => {
-        assert(!closed, "cannot attach a closed virtio device");
-        assert(!get_guest_config, "virtio device is already attached");
-        next_get_config().set(config);
-        get_guest_config = next_get_config;
-        raise_config = next_raise_config;
-        if (config_pending) {
-          config_pending = false;
-          raise_config();
-        }
-      },
-
-      notify: (vq, queue) => {
-        if (closed) return;
-        const handler = driver.queues[vq];
-        assert(handler, `virtio device has no queue ${vq}`);
-        const completion = Promise.withResolvers<void>();
-        active.add(completion.promise);
-        try {
-          Promise.resolve(handler(queue, this)).then(completion.resolve, completion.reject);
-        } catch (error) {
-          completion.reject(error);
-        }
-        void completion.promise.finally(() => active.delete(completion.promise)).catch(() => {});
-        return completion.promise;
-      },
-
-      reset: () => {
-        if (!closed) driver.reset?.();
-      },
-
+      queues: driver.queues.length,
+      closed: close_completion.promise,
+      connect: (context) =>
+        connect_local_virtio_device(context, {
+          features,
+          config,
+          attach: (next_get_config, next_raise_config) => {
+            assert(!closed, "cannot attach a closed virtio device");
+            assert(!get_guest_config, "virtio device is already attached");
+            next_get_config().set(config);
+            get_guest_config = next_get_config;
+            raise_config = next_raise_config;
+            if (config_pending) {
+              config_pending = false;
+              raise_config();
+            }
+          },
+          notify: (vq, queue) => {
+            if (closed) return;
+            const handler = driver.queues[vq];
+            assert(handler, `virtio device has no queue ${vq}`);
+            const completion = Promise.withResolvers<void>();
+            active.add(completion.promise);
+            try {
+              Promise.resolve(handler(queue, this)).then(
+                completion.resolve,
+                completion.reject,
+              );
+            } catch (error) {
+              completion.reject(error);
+            }
+            void completion.promise
+              .finally(() => active.delete(completion.promise))
+              .catch(() => {});
+            return completion.promise;
+          },
+          reset: () => {
+            if (!closed) driver.reset?.();
+          },
+        }),
       close: start_close,
     };
-    const device = {} as VirtioDevice;
-    const plugin: MachinePlugin = {
-      configure(setup) {
-        setup.devices.add(device);
-      },
-    };
-    Object.defineProperty(device, transport_device, { value: endpoint });
-    Object.defineProperty(device, getMachinePlugin, { value: () => plugin });
-    Object.defineProperty(device, "closed", { value: close_completion.promise, enumerable: true });
-    this.device = device;
+    this.device = create_virtio_device(endpoint);
 
     this.updateConfig = (next_config) => {
       assert(next_config.byteLength === config.byteLength, "virtio config size cannot change");
@@ -401,8 +492,8 @@ export class VirtioController {
     this.expose = <API extends object>(api: API) => {
       assert(!exposed, "virtio device API is already exposed");
       exposed = true;
-      Object.defineProperties(device, Object.getOwnPropertyDescriptors(api));
-      return device as VirtioDevice & API;
+      Object.defineProperties(this.device, Object.getOwnPropertyDescriptors(api));
+      return this.device as VirtioDevice & API;
     };
   }
 }
@@ -414,9 +505,107 @@ interface VirtqueueState {
   notifying: boolean;
 }
 
-interface TransportState {
-  device: TransportDevice;
-  queues: VirtqueueState[];
+interface LocalVirtioDevice {
+  features: bigint;
+  config: Uint8Array;
+  attach(get_config: () => Uint8Array, raise_config: RaiseConfigInterrupt): void;
+  notify(vq: number, queue: Virtqueue): void | PromiseLike<void>;
+  reset(): void;
+}
+
+function connect_local_virtio_device(
+  context: VirtioConnectionContext,
+  device: LocalVirtioDevice,
+): ConnectedVirtioDevice {
+  const queues: VirtqueueState[] = [];
+
+  const queue_state = (vq: number) =>
+    (queues[vq] ??= { queue: undefined, pending: false, notifying: false });
+
+  const drain_notifications = async (vq: number) => {
+    const state = queue_state(vq);
+    if (state.notifying || !state.queue) return;
+    state.notifying = true;
+    try {
+      do {
+        state.pending = false;
+        await device.notify(vq, state.queue);
+      } while (state.pending && state.queue);
+    } catch (error) {
+      context.on_error(error);
+    } finally {
+      state.notifying = false;
+    }
+  };
+
+  return {
+    set_features(features) {
+      assert(
+        device.features === features,
+        "the kernel should accept every feature we offer, and no more",
+      );
+    },
+    setup(config_irq, _config_address, config_length) {
+      assert(config_length >= device.config.byteLength, "config space too small");
+      const config = context.config_target
+        ? context.config_target(config_length)
+        : new Uint8Array(context.memory.buffer, _config_address, config_length);
+      device.attach(
+        () => config,
+        () => {
+          if (context.publish_config) context.publish_config(config_irq, config.slice(), true);
+          else context.trigger_irq(config_irq);
+        },
+      );
+      context.publish_config?.(config_irq, config.slice(), false);
+    },
+    enable_queue(vq, size, descriptor_address, irq) {
+      const state = queue_state(vq);
+      state.queue?.invalidate();
+      let armed = false;
+      const queue = new PackedVirtqueue(
+        context.memory,
+        size,
+        descriptor_address,
+        (completion) => {
+          if (context.publish_completion) {
+            context.publish_completion(vq, irq, completion);
+            return;
+          }
+          publish_virtqueue_completion(context.memory, completion);
+          if (armed) return;
+          armed = true;
+          queueMicrotask(() => {
+            armed = false;
+            if (state.queue === queue) context.trigger_irq(irq);
+          });
+        },
+        () => state.queue === queue && (context.queue_is_current?.(vq) ?? true),
+      );
+      state.queue = queue;
+      if (state.pending) void drain_notifications(vq);
+    },
+    disable_queue(vq) {
+      const state = queues[vq];
+      state?.queue?.invalidate();
+      if (!state) return;
+      state.queue = undefined;
+      state.pending = false;
+    },
+    notify(vq) {
+      queue_state(vq).pending = true;
+      void drain_notifications(vq);
+    },
+    reset() {
+      for (const state of queues) {
+        if (!state) continue;
+        state.queue?.invalidate();
+        state.queue = undefined;
+        state.pending = false;
+      }
+      device.reset();
+    },
+  };
 }
 
 export function virtio_device_description(device: VirtioDevice) {
@@ -425,7 +614,15 @@ export function virtio_device_description(device: VirtioDevice) {
     device_id: transport.device_id,
     features: transport.features,
     config: transport.config,
+    queues: transport.queues,
   };
+}
+
+export function connect_virtio_device(
+  device: VirtioDevice,
+  context: VirtioConnectionContext,
+) {
+  return device[transport_device].connect(context);
 }
 
 export function close_virtio_device(device: VirtioDevice) {
@@ -443,102 +640,45 @@ export function virtio_imports({
   trigger_irq: (irq: number) => void;
   on_error: (error: unknown) => void;
 }): Imports["virtio"] {
-  const states: TransportState[] = devices.map((device) => ({
-    device: device[transport_device],
-    queues: [],
-  }));
-
-  function queue_state(device: TransportState, vq: number) {
-    return (device.queues[vq] ??= {
-      queue: undefined,
-      pending: false,
-      notifying: false,
-    });
-  }
-
-  const drain_notifications = async (device: TransportState, vq: number) => {
-    const state = queue_state(device, vq);
-    if (state.notifying || !state.queue) return;
-
-    state.notifying = true;
-    try {
-      do {
-        state.pending = false;
-        await device.device.notify(vq, state.queue);
-      } while (state.pending && state.queue);
-    } catch (error) {
-      on_error(error);
-    } finally {
-      state.notifying = false;
-    }
-  };
+  const connected = devices.map((device) =>
+    device[transport_device].connect({ memory, trigger_irq, on_error }),
+  );
 
   return {
     set_features(dev, features) {
-      const device = states[dev]?.device;
+      const device = connected[dev];
       assert(device);
-      assert(
-        device.features === features,
-        "the kernel should accept every feature we offer, and no more",
-      );
+      device.set_features(features);
     },
 
     enable_vring(dev, vq, size, desc_addr, irq) {
-      const device = states[dev];
+      const device = connected[dev];
       assert(device);
-      const state = queue_state(device, vq);
-      state.queue?.invalidate();
-      // Interrupt once per synchronous batch of released chains.
-      let armed = false;
-      const queue: PackedVirtqueue = new PackedVirtqueue(memory, size, desc_addr >>> 0, () => {
-        if (armed) return;
-        armed = true;
-        queueMicrotask(() => {
-          armed = false;
-          if (state.queue === queue) trigger_irq(irq);
-        });
-      });
-      state.queue = queue;
-      if (state.pending) void drain_notifications(device, vq);
+      device.enable_queue(vq, size, desc_addr >>> 0, irq);
     },
     disable_vring(dev, vq) {
-      const device = states[dev];
+      const device = connected[dev];
       assert(device);
-      const state = device.queues[vq];
-      state?.queue?.invalidate();
-      if (!state) return;
-      state.queue = undefined;
-      state.pending = false;
+      device.disable_queue(vq);
     },
     reset(dev) {
-      const device = states[dev];
+      const device = connected[dev];
       assert(device);
-      for (const state of device.queues) {
-        if (!state) continue;
-        state.queue?.invalidate();
-        state.queue = undefined;
-        state.pending = false;
-      }
-      device.device.reset();
+      device.reset();
     },
 
     setup(dev, config_irq, config_addr, config_len) {
       const address = config_addr >>> 0;
       const length = config_len >>> 0;
-      const device = states[dev]?.device;
+      const device = connected[dev];
       assert(device);
-      assert(length >= device.config.byteLength, "config space too small");
-      device.attach(
-        () => new Uint8Array(memory.buffer, address, length),
-        () => trigger_irq(config_irq),
-      );
+      device.setup(config_irq, address, length);
     },
 
     notify(dev, vq) {
-      const device = states[dev];
+      const device = connected[dev];
       assert(device);
-      queue_state(device, vq).pending = true;
-      void drain_notifications(device, vq);
+      device.notify(vq);
     },
   };
 }

--- a/packages/kernel/src/virtio/core.ts
+++ b/packages/kernel/src/virtio/core.ts
@@ -314,12 +314,7 @@ export interface VirtioDriver {
 export interface ConnectedVirtioDevice {
   set_features(features: bigint): void;
   setup(config_irq: number, config_address: number, config_length: number): void;
-  enable_queue(
-    vq: number,
-    size: number,
-    descriptor_address: number,
-    irq: number,
-  ): void;
+  enable_queue(vq: number, size: number, descriptor_address: number, irq: number): void;
   disable_queue(vq: number): void;
   notify(vq: number): void;
   reset(): void;
@@ -332,11 +327,7 @@ export interface VirtioConnectionContext {
   // A remote connection replaces only publication. Queue traversal and the
   // driver remain unchanged, while the main thread retains the final writes
   // to guest memory. Local connections omit these hooks.
-  publish_completion?(
-    vq: number,
-    irq: number,
-    completion: VirtqueueCompletion,
-  ): void;
+  publish_completion?(vq: number, irq: number, completion: VirtqueueCompletion): void;
   queue_is_current?(vq: number): boolean;
   config_target?(length: number): Uint8Array;
   publish_config?(irq: number, config: Uint8Array, interrupt: boolean): void;
@@ -459,10 +450,7 @@ export class VirtioController {
             const completion = Promise.withResolvers<void>();
             active.add(completion.promise);
             try {
-              Promise.resolve(handler(queue, this)).then(
-                completion.resolve,
-                completion.reject,
-              );
+              Promise.resolve(handler(queue, this)).then(completion.resolve, completion.reject);
             } catch (error) {
               completion.reject(error);
             }
@@ -618,10 +606,7 @@ export function virtio_device_description(device: VirtioDevice) {
   };
 }
 
-export function connect_virtio_device(
-  device: VirtioDevice,
-  context: VirtioConnectionContext,
-) {
+export function connect_virtio_device(device: VirtioDevice, context: VirtioConnectionContext) {
   return device[transport_device].connect(context);
 }
 

--- a/packages/kernel/src/virtio/remote.ts
+++ b/packages/kernel/src/virtio/remote.ts
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { assert } from "../util.ts";
-import {
-  listen_endpoint,
-  post_endpoint,
-  type Endpoint,
-} from "../endpoint.ts";
+import { listen_endpoint, post_endpoint, type Endpoint } from "../endpoint.ts";
 export type { Endpoint } from "../endpoint.ts";
 import {
   close_virtio_device,
@@ -225,7 +221,8 @@ function connect_remote_device(
           !enabled[message.vq] ||
           Atomics.load(control, 0) !== message.device_epoch ||
           Atomics.load(control, 1 + message.vq) !== message.queue_epoch
-        ) return;
+        )
+          return;
         publish_virtqueue_completion(context.memory, message.completion);
         context.trigger_irq(message.irq);
         return;
@@ -322,10 +319,10 @@ export function serveDevice(endpoint: Endpoint, device: VirtioDevice): void {
   let closing = false;
 
   const send_error = (error: unknown) =>
-    post_endpoint(
-      endpoint,
-      { type: "error", error: serialize_error(error) } satisfies WorkerMessage,
-    );
+    post_endpoint(endpoint, {
+      type: "error",
+      error: serialize_error(error),
+    } satisfies WorkerMessage);
 
   let stop_listening = () => {};
   const on_message = (value: unknown) => {
@@ -355,7 +352,8 @@ export function serveDevice(endpoint: Endpoint, device: VirtioDevice): void {
               if (
                 Atomics.load(control!, 0) !== device_epoch ||
                 Atomics.load(control!, 1 + vq) !== queue_epochs[vq]
-              ) return;
+              )
+                return;
               const transfer = completion.outputs.map(({ data }) => data.buffer);
               post_endpoint(
                 endpoint,
@@ -408,13 +406,10 @@ export function serveDevice(endpoint: Endpoint, device: VirtioDevice): void {
             },
             (error) => {
               stop_listening();
-              post_endpoint(
-                endpoint,
-                {
-                  type: "closed",
-                  error: serialize_error(error),
-                } satisfies WorkerMessage,
-              );
+              post_endpoint(endpoint, {
+                type: "closed",
+                error: serialize_error(error),
+              } satisfies WorkerMessage);
             },
           );
           return;

--- a/packages/kernel/src/virtio/remote.ts
+++ b/packages/kernel/src/virtio/remote.ts
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: MIT
+
+import { assert } from "../util.ts";
+import {
+  listen_endpoint,
+  post_endpoint,
+  type Endpoint,
+} from "../endpoint.ts";
+export type { Endpoint } from "../endpoint.ts";
+import {
+  close_virtio_device,
+  connect_virtio_device,
+  create_virtio_device,
+  publish_virtqueue_completion,
+  virtio_device_description,
+  type ConnectedVirtioDevice,
+  type TransportDevice,
+  type VirtioDevice,
+  type VirtqueueCompletion,
+} from "./core.ts";
+
+/*
+ * The queue protocol deliberately has no request IDs or acknowledgements.
+ * Transport operations flow to the worker in MessagePort order; completions
+ * flow back in the other direction. The only cross-direction queue coordination
+ * is the shared revocation array used by reset. Descriptor payloads are
+ * transferred back, then committed to guest memory by the main thread.
+ */
+
+interface SerializedError {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+type ReadyMessage = {
+  type: "ready";
+  device_id: number;
+  features: bigint;
+  config: Uint8Array;
+  queues: number;
+};
+
+type CompletionMessage = {
+  type: "complete";
+  vq: number;
+  irq: number;
+  device_epoch: number;
+  queue_epoch: number;
+  completion: VirtqueueCompletion;
+};
+
+type WorkerMessage =
+  | ReadyMessage
+  | CompletionMessage
+  | { type: "config"; irq: number; config: Uint8Array; interrupt: boolean }
+  | { type: "error"; error: SerializedError }
+  | { type: "closed"; error?: SerializedError };
+
+type DeviceMessage =
+  | { type: "bind"; memory: WebAssembly.Memory; control: SharedArrayBuffer }
+  | { type: "features"; features: bigint }
+  | { type: "setup"; config_irq: number; config_length: number }
+  | {
+      type: "enable";
+      vq: number;
+      size: number;
+      descriptor_address: number;
+      irq: number;
+      device_epoch: number;
+      queue_epoch: number;
+    }
+  | { type: "disable"; vq: number }
+  | { type: "notify"; vq: number }
+  | { type: "reset" }
+  | { type: "close" };
+
+const serialize_error = (error: unknown): SerializedError => {
+  const value = error instanceof Error ? error : new Error(String(error));
+  return { name: value.name, message: value.message, stack: value.stack };
+};
+
+const deserialize_error = ({ name, message, stack }: SerializedError) => {
+  const error = new Error(message);
+  error.name = name;
+  error.stack = stack;
+  return error;
+};
+
+/**
+ * Creates an attachable virtio device whose driver and queue traversal live in
+ * `endpoint`, normally a dedicated Worker serving a device with `serveDevice`.
+ *
+ * The endpoint may instead be a MessagePort. That form is useful when the
+ * caller needs to initialize a worker with other data, or serve several
+ * devices from one worker. Closing the device closes this protocol and its
+ * driver; ownership of the Worker or MessagePort remains with the caller.
+ *
+ * @example
+ * ```ts
+ * const device = await workerDevice(new Worker("./disk-worker.js", { type: "module" }));
+ * ```
+ */
+export function workerDevice(endpoint: Endpoint): Promise<VirtioDevice> {
+  endpoint.start?.();
+
+  return new Promise((resolve, reject) => {
+    let cleanup = () => {};
+    const fail = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    cleanup = listen_endpoint(endpoint, {
+      message(value) {
+        const message = value as WorkerMessage;
+        if (message?.type === "error") {
+          fail(deserialize_error(message.error));
+          return;
+        }
+        if (message?.type !== "ready") return;
+        // Install the device's lifetime listeners before removing the startup
+        // listeners. No worker failure can fall between ready and attachment.
+        const device = create_remote_device(endpoint, message);
+        cleanup();
+        resolve(device);
+      },
+      error: fail,
+    });
+  });
+}
+
+function create_remote_device(endpoint: Endpoint, ready: ReadyMessage): VirtioDevice {
+  const config = ready.config.slice();
+  const close_completion = Promise.withResolvers<void>();
+  void close_completion.promise.catch(() => {});
+  let connection: ReturnType<typeof connect_remote_device> | undefined;
+  let terminal_error: Error | undefined;
+  let close_started = false;
+
+  let cleanup = () => {};
+  const fail = (error: Error) => {
+    terminal_error ??= error;
+    connection?.fail(error);
+    close_completion.reject(error);
+  };
+  const receive = (value: unknown) => {
+    const message = value as WorkerMessage;
+    if (message?.type === "closed") {
+      cleanup();
+      if (message.error) {
+        const error = deserialize_error(message.error);
+        connection?.fail(error);
+        close_completion.reject(error);
+      } else {
+        close_completion.resolve();
+      }
+      return;
+    }
+    if (message?.type === "error" && !connection) {
+      fail(deserialize_error(message.error));
+      return;
+    }
+    connection?.receive(message);
+  };
+  const endpoint_failure = (error: Error) => {
+    cleanup();
+    fail(error);
+  };
+  cleanup = listen_endpoint(endpoint, {
+    message: receive,
+    error: endpoint_failure,
+  });
+
+  const transport: TransportDevice = {
+    device_id: ready.device_id,
+    features: ready.features,
+    config,
+    queues: ready.queues,
+    closed: close_completion.promise,
+    connect(context) {
+      assert(!connection, "remote virtio device is already attached");
+      if (terminal_error) throw terminal_error;
+      connection = connect_remote_device(endpoint, transport, context);
+      return connection.device;
+    },
+    close() {
+      if (close_started) return close_completion.promise;
+      close_started = true;
+      connection?.revoke();
+      post_endpoint(endpoint, { type: "close" } satisfies DeviceMessage);
+      return close_completion.promise;
+    },
+  };
+  return create_virtio_device(transport);
+}
+
+function connect_remote_device(
+  endpoint: Endpoint,
+  transport: TransportDevice,
+  context: Parameters<TransportDevice["connect"]>[0],
+) {
+  // Slot zero revokes the whole device; the remaining slots revoke individual
+  // queues. Reset changes slot zero synchronously on the main thread. A worker
+  // may finish old work, but its completion cannot pass the main-thread check.
+  const control_buffer = new SharedArrayBuffer(
+    Int32Array.BYTES_PER_ELEMENT * (1 + transport.queues),
+  );
+  const control = new Int32Array(control_buffer);
+  const queue_epochs = new Int32Array(transport.queues);
+  const enabled = new Uint8Array(transport.queues);
+  let config_target: Uint8Array | undefined;
+  let failed = false;
+
+  const fail = (error: unknown) => {
+    if (failed) return;
+    failed = true;
+    Atomics.add(control, 0, 1);
+    context.on_error(error);
+  };
+
+  const receive = (message: WorkerMessage) => {
+    switch (message?.type) {
+      case "complete": {
+        if (
+          !enabled[message.vq] ||
+          Atomics.load(control, 0) !== message.device_epoch ||
+          Atomics.load(control, 1 + message.vq) !== message.queue_epoch
+        ) return;
+        publish_virtqueue_completion(context.memory, message.completion);
+        context.trigger_irq(message.irq);
+        return;
+      }
+      case "config":
+        transport.config.set(message.config.subarray(0, transport.config.byteLength));
+        config_target?.set(message.config);
+        if (message.interrupt) context.trigger_irq(message.irq);
+        return;
+      case "error":
+        fail(deserialize_error(message.error));
+        return;
+    }
+  };
+  post_endpoint(endpoint, {
+    type: "bind",
+    memory: context.memory,
+    control: control_buffer,
+  } satisfies DeviceMessage);
+
+  const device: ConnectedVirtioDevice = {
+    set_features(features) {
+      assert(features === transport.features);
+      post_endpoint(endpoint, { type: "features", features } satisfies DeviceMessage);
+    },
+    setup(config_irq, config_address, config_length) {
+      assert(config_length >= transport.config.byteLength, "config space too small");
+      config_target = new Uint8Array(context.memory.buffer, config_address, config_length);
+      config_target.set(transport.config);
+      post_endpoint(endpoint, { type: "setup", config_irq, config_length } satisfies DeviceMessage);
+    },
+    enable_queue(vq, size, descriptor_address, irq) {
+      assert(vq < transport.queues, `virtio device has no queue ${vq}`);
+      Atomics.add(control, 1 + vq, 1);
+      const queue_epoch = (queue_epochs[vq] = Atomics.load(control, 1 + vq));
+      const device_epoch = Atomics.load(control, 0);
+      enabled[vq] = 1;
+      post_endpoint(endpoint, {
+        type: "enable",
+        vq,
+        size,
+        descriptor_address,
+        irq,
+        device_epoch,
+        queue_epoch,
+      } satisfies DeviceMessage);
+    },
+    disable_queue(vq) {
+      assert(vq < transport.queues, `virtio device has no queue ${vq}`);
+      enabled[vq] = 0;
+      Atomics.add(control, 1 + vq, 1);
+      post_endpoint(endpoint, { type: "disable", vq } satisfies DeviceMessage);
+    },
+    notify(vq) {
+      post_endpoint(endpoint, { type: "notify", vq } satisfies DeviceMessage);
+    },
+    reset() {
+      // This executes inside the synchronous Wasm import. Since completions are
+      // also committed on this thread, none can interleave between revocation
+      // and the rest of reset; no acknowledgement or fence is necessary.
+      Atomics.add(control, 0, 1);
+      enabled.fill(0);
+      post_endpoint(endpoint, { type: "reset" } satisfies DeviceMessage);
+    },
+  };
+
+  return {
+    device,
+    receive,
+    fail,
+    revoke() {
+      Atomics.add(control, 0, 1);
+      enabled.fill(0);
+    },
+  };
+}
+
+/**
+ * Serves `device` over `endpoint` for `workerDevice` to attach to a machine.
+ * In a dedicated worker, the usual endpoint is `self`; a MessagePort is useful
+ * when the worker needs other initialization or serves more than one device.
+ *
+ * @example
+ * ```ts
+ * serveDevice(self, blockDevice(storage));
+ * ```
+ */
+export function serveDevice(endpoint: Endpoint, device: VirtioDevice): void {
+  const description = virtio_device_description(device);
+  let connected: ConnectedVirtioDevice | undefined;
+  let control: Int32Array | undefined;
+  let device_epoch = 0;
+  const queue_epochs = new Int32Array(description.queues);
+  let closing = false;
+
+  const send_error = (error: unknown) =>
+    post_endpoint(
+      endpoint,
+      { type: "error", error: serialize_error(error) } satisfies WorkerMessage,
+    );
+
+  let stop_listening = () => {};
+  const on_message = (value: unknown) => {
+    const message = value as DeviceMessage;
+    try {
+      switch (message?.type) {
+        case "bind":
+          assert(!connected, "virtio device is already bound");
+          control = new Int32Array(message.control);
+          connected = connect_virtio_device(device, {
+            memory: message.memory,
+            trigger_irq: () => assert(false, "remote interrupts are published with state"),
+            on_error: send_error,
+            config_target: (length) => new Uint8Array(length),
+            publish_config: (irq, value, interrupt) => {
+              const copy = value.slice();
+              post_endpoint(
+                endpoint,
+                { type: "config", irq, config: copy, interrupt } satisfies WorkerMessage,
+                [copy.buffer],
+              );
+            },
+            queue_is_current: (vq) =>
+              Atomics.load(control!, 0) === device_epoch &&
+              Atomics.load(control!, 1 + vq) === queue_epochs[vq],
+            publish_completion: (vq, irq, completion) => {
+              if (
+                Atomics.load(control!, 0) !== device_epoch ||
+                Atomics.load(control!, 1 + vq) !== queue_epochs[vq]
+              ) return;
+              const transfer = completion.outputs.map(({ data }) => data.buffer);
+              post_endpoint(
+                endpoint,
+                {
+                  type: "complete",
+                  vq,
+                  irq,
+                  device_epoch,
+                  queue_epoch: queue_epochs[vq]!,
+                  completion,
+                } satisfies WorkerMessage,
+                transfer,
+              );
+            },
+          });
+          return;
+        case "features":
+          connected?.set_features(message.features);
+          return;
+        case "setup":
+          connected?.setup(message.config_irq, 0, message.config_length);
+          return;
+        case "enable":
+          device_epoch = message.device_epoch;
+          queue_epochs[message.vq] = message.queue_epoch;
+          connected?.enable_queue(
+            message.vq,
+            message.size,
+            message.descriptor_address,
+            message.irq,
+          );
+          return;
+        case "disable":
+          connected?.disable_queue(message.vq);
+          return;
+        case "notify":
+          connected?.notify(message.vq);
+          return;
+        case "reset":
+          device_epoch = Atomics.load(control!, 0);
+          connected?.reset();
+          return;
+        case "close":
+          if (closing) return;
+          closing = true;
+          void close_virtio_device(device).then(
+            () => {
+              stop_listening();
+              post_endpoint(endpoint, { type: "closed" } satisfies WorkerMessage);
+            },
+            (error) => {
+              stop_listening();
+              post_endpoint(
+                endpoint,
+                {
+                  type: "closed",
+                  error: serialize_error(error),
+                } satisfies WorkerMessage,
+              );
+            },
+          );
+          return;
+      }
+    } catch (error) {
+      send_error(error);
+    }
+  };
+
+  stop_listening = listen_endpoint(endpoint, { message: on_message });
+  endpoint.start?.();
+  const ready_config = description.config.slice();
+  post_endpoint(
+    endpoint,
+    { type: "ready", ...description, config: ready_config } satisfies WorkerMessage,
+    [ready_config.buffer],
+  );
+}

--- a/packages/kernel/src/virtio/remote.ts
+++ b/packages/kernel/src/virtio/remote.ts
@@ -90,7 +90,8 @@ const deserialize_error = ({ name, message, stack }: SerializedError) => {
  * The endpoint may instead be a MessagePort. That form is useful when the
  * caller needs to initialize a worker with other data, or serve several
  * devices from one worker. Closing the device closes this protocol and its
- * driver; ownership of the Worker or MessagePort remains with the caller.
+ * driver; ownership of the Worker or MessagePort remains with the caller. The
+ * caller must keep that endpoint alive until `device.closed` settles.
  *
  * @example
  * ```ts

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+import { listen_endpoint, post_endpoint } from "./endpoint.ts";
 import { platform } from "./platform.ts";
 import { assert } from "./util.ts";
 import { read_wasm_memories } from "./wasm_binary.ts";
@@ -45,8 +46,9 @@ const unavailable = () => {
   throw new Error("not available on worker thread");
 };
 
-const channel = platform.worker_channel();
-const postMessage = channel.post as (message: WorkerMessage, transfer?: Transferable[]) => void;
+const endpoint = platform.worker_endpoint();
+const postMessage = (message: WorkerMessage, transfer?: Transferable[]) =>
+  post_endpoint(endpoint, message, transfer);
 
 function user_imports({
   kernel_memory,
@@ -503,20 +505,22 @@ function start({
   }
 }
 
-channel.on_message((raw) => {
-  const message = raw as InitMessage | ForwardedInitMessage;
+listen_endpoint(endpoint, {
+  message(raw) {
+    const message = raw as InitMessage | ForwardedInitMessage;
 
-  // Initial workers receive InitMessage directly from the page. Workers
-  // spawned by another worker receive their InitMessage over this port, which
-  // works around a WebKit bug reclaiming shared Wasm memory across JS VMs.
-  if (message.type === "forwarded_init") {
-    message.port.onmessage = ({ data }) => {
-      message.port.close();
-      start(data as InitMessage);
-    };
-    message.port.start();
-    return;
-  }
+    // Initial workers receive InitMessage directly from the page. Workers
+    // spawned by another worker receive their InitMessage over this port, which
+    // works around a WebKit bug reclaiming shared Wasm memory across JS VMs.
+    if (message.type === "forwarded_init") {
+      message.port.onmessage = ({ data }) => {
+        message.port.close();
+        start(data as InitMessage);
+      };
+      message.port.start();
+      return;
+    }
 
-  start(message);
+    start(message);
+  },
 });

--- a/packages/kernel/test/wasm.test.ts
+++ b/packages/kernel/test/wasm.test.ts
@@ -512,7 +512,7 @@ test("an unattached remote virtio device can be closed", async () => {
   let closes = 0;
   const served = blockDevice({
     capacity: 512,
-    read: (_offset, length) => new Uint8Array(length),
+    read: (_offset, target) => target.byteLength,
     close() {
       closes += 1;
     },
@@ -530,7 +530,7 @@ test("an unattached remote virtio device can be closed", async () => {
 test("a worker-device failure after ready is observed before attachment", async () => {
   const served = blockDevice({
     capacity: 512,
-    read: (_offset, length) => new Uint8Array(length),
+    read: (_offset, target) => target.byteLength,
   });
   const channel = new MessageChannel();
   serveDevice(channel.port1, served);

--- a/packages/kernel/test/wasm.test.ts
+++ b/packages/kernel/test/wasm.test.ts
@@ -4,10 +4,12 @@ import assert from "node:assert/strict";
 import { once } from "node:events";
 import test from "node:test";
 import { Worker } from "node:worker_threads";
+import { blockDevice } from "../src/virtio/block.ts";
 import { consoleDevice } from "../src/virtio/console.ts";
 import { ethernetDevice, ethernetNetwork } from "../src/virtio/net.ts";
 import { vsockDevice } from "../src/virtio/vsock.ts";
 import { VirtioController, close_virtio_device, virtio_imports } from "../src/virtio/core.ts";
+import { serveDevice, workerDevice } from "../src/virtio/remote.ts";
 import {
   allocate_shared_memory,
   memory_bytes,
@@ -402,6 +404,173 @@ test("virtio reset invalidates stale chains and pending notifications", async ()
   assert.notEqual(restored_descriptor.getUint16(14, true) & (1 << 15), 0);
   await Promise.resolve();
   assert.equal(interrupts, 1);
+});
+
+test("a remote virtio worker owns chains but the main thread publishes completions", async () => {
+  const remote_memory = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+  const first_chain = Promise.withResolvers<{
+    array: Uint8Array;
+    release(written: number): void;
+  }>();
+  const stale_chain = Promise.withResolvers<{
+    array: Uint8Array;
+    release(written: number): void;
+  }>();
+  let notifications = 0;
+  let resets = 0;
+  let closes = 0;
+  const controller = new VirtioController(
+    { deviceId: 2, config: Uint8Array.of(7) },
+    {
+      queues: [
+        (queue) => {
+          const [chain] = queue;
+          assert(chain);
+          const [buffer] = chain;
+          assert(buffer?.writable);
+          notifications += 1;
+          (notifications === 1 ? first_chain : stale_chain).resolve({
+            array: buffer.array,
+            release: (written) => chain.release(written),
+          });
+        },
+      ],
+      reset() {
+        resets += 1;
+      },
+      close() {
+        closes += 1;
+      },
+    },
+  );
+  const channel = new MessageChannel();
+  serveDevice(channel.port1, controller.device);
+  const device = await workerDevice(channel.port2);
+  const interrupts: number[] = [];
+  const errors: unknown[] = [];
+  const imports = virtio_imports({
+    memory: remote_memory,
+    devices: [device],
+    trigger_irq: (irq) => interrupts.push(irq),
+    on_error: (error) => errors.push(error),
+  });
+  const queue_descriptor = (ring: number, address: number) => {
+    const descriptor = new DataView(remote_memory.buffer, ring, 16);
+    descriptor.setBigUint64(0, BigInt(address), true);
+    descriptor.setUint32(8, 1, true);
+    descriptor.setUint16(12, 0, true);
+    descriptor.setUint16(14, (1 << 7) | (1 << 1), true);
+    return descriptor;
+  };
+
+  const config_address = 256;
+  imports.setup(0, 3, config_address, 1);
+  assert.equal(new Uint8Array(remote_memory.buffer, config_address, 1)[0], 7);
+
+  const descriptor = queue_descriptor(0, 64);
+  imports.enable_vring(0, 0, 1, 0, 5);
+  imports.notify(0, 0);
+  const first = await first_chain.promise;
+  first.array[0] = 0xaa;
+  first.release(1);
+  await new Promise<void>((resolve) => {
+    const check = () => (interrupts.length ? resolve() : setTimeout(check, 0));
+    check();
+  });
+  assert.equal(new Uint8Array(remote_memory.buffer, 64, 1)[0], 0xaa);
+  assert.equal(descriptor.getUint32(8, true), 1);
+  assert.equal(descriptor.getUint16(14, true), (1 << 15) | (1 << 7) | (1 << 1));
+  assert.deepEqual(interrupts, [5]);
+
+  controller.updateConfig(Uint8Array.of(9));
+  await new Promise<void>((resolve) => {
+    const check = () => (interrupts.includes(3) ? resolve() : setTimeout(check, 0));
+    check();
+  });
+  assert.equal(new Uint8Array(remote_memory.buffer, config_address, 1)[0], 9);
+
+  queue_descriptor(128, 192);
+  imports.enable_vring(0, 0, 1, 128, 6);
+  imports.notify(0, 0);
+  const stale = await stale_chain.promise;
+  imports.reset(0);
+  stale.array[0] = 0xbb;
+  stale.release(1);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(new Uint8Array(remote_memory.buffer, 192, 1)[0], 0);
+  assert.deepEqual(interrupts, [5, 3]);
+  assert.equal(resets, 1);
+  assert.deepEqual(errors, []);
+
+  await close_virtio_device(device);
+  assert.equal(closes, 1);
+  channel.port1.close();
+  channel.port2.close();
+});
+
+test("an unattached remote virtio device can be closed", async () => {
+  let closes = 0;
+  const served = blockDevice({
+    capacity: 512,
+    read: (_offset, length) => new Uint8Array(length),
+    close() {
+      closes += 1;
+    },
+  });
+  const channel = new MessageChannel();
+  serveDevice(channel.port1, served);
+  const device = await workerDevice(channel.port2);
+
+  await close_virtio_device(device);
+  assert.equal(closes, 1);
+  channel.port1.close();
+  channel.port2.close();
+});
+
+test("a worker-device failure after ready is observed before attachment", async () => {
+  const served = blockDevice({
+    capacity: 512,
+    read: (_offset, length) => new Uint8Array(length),
+  });
+  const channel = new MessageChannel();
+  serveDevice(channel.port1, served);
+  const device = await workerDevice(channel.port2);
+
+  channel.port1.postMessage({
+    type: "error",
+    error: { name: "Error", message: "worker failed after ready" },
+  });
+  await assert.rejects(device.closed, /worker failed after ready/);
+  await assert.rejects(close_virtio_device(device), /worker failed after ready/);
+
+  await close_virtio_device(served);
+  channel.port1.close();
+  channel.port2.close();
+});
+
+test("workerDevice accepts a Node Worker endpoint", async () => {
+  const worker = new Worker(
+    `
+      const { parentPort } = require("node:worker_threads");
+      parentPort.postMessage({
+        type: "ready",
+        device_id: 4,
+        features: 0n,
+        config: new Uint8Array(),
+        queues: 0,
+      });
+      parentPort.on("message", (message) => {
+        if (message.type === "close") parentPort.postMessage({ type: "closed" });
+      });
+    `,
+    { eval: true },
+  );
+  try {
+    const device = await workerDevice(worker);
+    await close_virtio_device(device);
+  } finally {
+    await worker.terminate();
+  }
 });
 
 test("virtio close drains active queue work before one-time cleanup", async () => {

--- a/packages/kernel/test/wasm.test.ts
+++ b/packages/kernel/test/wasm.test.ts
@@ -191,6 +191,48 @@ test("virtio-net preserves pending frames but drops receive chains on reset", as
   network.close();
 });
 
+test("virtio block reports a short caller-buffer read as IOERR", async () => {
+  const block_memory = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+  const device = blockDevice({
+    capacity: 512,
+    read(_offset, target) {
+      target.fill(0xaa);
+      return target.byteLength - 1;
+    },
+  });
+  const interrupted = Promise.withResolvers<void>();
+  const imports = virtio_imports({
+    memory: block_memory,
+    devices: [device],
+    trigger_irq() {
+      interrupted.resolve();
+    },
+    on_error(error) {
+      interrupted.reject(error);
+    },
+  });
+  const descriptor = (index: number, address: number, length: number, flags: number) => {
+    const view = new DataView(block_memory.buffer, index * 16, 16);
+    view.setBigUint64(0, BigInt(address), true);
+    view.setUint32(8, length, true);
+    view.setUint16(14, flags, true);
+  };
+  const available = 1 << 7;
+  const next = 1;
+  const writable = 1 << 1;
+  descriptor(0, 128, 16, available | next);
+  descriptor(1, 256, 512, available | next | writable);
+  descriptor(2, 1024, 1, available | writable);
+  new Uint8Array(block_memory.buffer, 1024, 1)[0] = 0xff;
+
+  imports.enable_vring(0, 0, 4, 0, 1);
+  imports.notify(0, 0);
+  await interrupted.promise;
+
+  assert.equal(new Uint8Array(block_memory.buffer, 1024, 1)[0], 1);
+  await close_virtio_device(device);
+});
+
 test("console input is held until the guest opens its port", async () => {
   const console_memory = new WebAssembly.Memory({
     initial: 1,

--- a/packages/linux-guest/README.md
+++ b/packages/linux-guest/README.md
@@ -16,7 +16,11 @@ import { blockDevice, spawnGuest } from "@tombl/linux-guest";
 const rootfs = new Uint8Array(await fetch("/rootfs.erofs").then((r) => r.arrayBuffer()));
 const root = blockDevice({
   capacity: rootfs.byteLength,
-  read: (offset, length) => rootfs.subarray(offset, offset + length),
+  read(offset, target) {
+    const source = rootfs.subarray(offset, offset + target.byteLength);
+    target.set(source);
+    return source.byteLength;
+  },
 });
 const guest = await spawnGuest({ cpus: 1, root });
 const process = await guest.exec(["uname", "-a"]);

--- a/packages/linux-guest/src/machine.ts
+++ b/packages/linux-guest/src/machine.ts
@@ -53,8 +53,10 @@ async function agent_device() {
   const bytes = await agent_image;
   return blockDevice({
     capacity: bytes.byteLength,
-    read(offset, length) {
-      return bytes.subarray(offset, offset + length);
+    read(offset, target) {
+      const source = bytes.subarray(offset, offset + target.byteLength);
+      target.set(source);
+      return source.byteLength;
     },
   });
 }

--- a/packages/linux-guest/tests/assets.ts
+++ b/packages/linux-guest/tests/assets.ts
@@ -33,8 +33,10 @@ export const wrong_rootfs = await readFile(join(directory, "wrong-root.erofs"));
 export function root_device() {
   return blockDevice({
     capacity: rootfs.byteLength,
-    read(offset, length) {
-      return rootfs.subarray(offset, offset + length);
+    read(offset, target) {
+      const source = rootfs.subarray(offset, offset + target.byteLength);
+      target.set(source);
+      return source.byteLength;
     },
   });
 }
@@ -43,8 +45,10 @@ export function ext4_root_device() {
   const disk = new Uint8Array(ext4_rootfs);
   return blockDevice({
     capacity: disk.byteLength,
-    read(offset, length) {
-      return disk.slice(offset, offset + length);
+    read(offset, target) {
+      const source = disk.subarray(offset, offset + target.byteLength);
+      target.set(source);
+      return source.byteLength;
     },
     write(offset, data) {
       disk.set(data, offset);
@@ -57,8 +61,10 @@ export function ext4_root_device() {
 export function agent_device() {
   return blockDevice({
     capacity: agentfs.byteLength,
-    read(offset, length) {
-      return agentfs.subarray(offset, offset + length);
+    read(offset, target) {
+      const source = agentfs.subarray(offset, offset + target.byteLength);
+      target.set(source);
+      return source.byteLength;
     },
   });
 }
@@ -66,8 +72,10 @@ export function agent_device() {
 export function wrong_root_device() {
   return blockDevice({
     capacity: wrong_rootfs.byteLength,
-    read(offset, length) {
-      return wrong_rootfs.subarray(offset, offset + length);
+    read(offset, target) {
+      const source = wrong_rootfs.subarray(offset, offset + target.byteLength);
+      target.set(source);
+      return source.byteLength;
     },
   });
 }

--- a/packages/linux-guest/tests/guest.test.ts
+++ b/packages/linux-guest/tests/guest.test.ts
@@ -113,8 +113,10 @@ test("rejects a system disk without a label", async () => {
       cpus: 1,
       root: blockDevice({
         capacity: empty.byteLength,
-        read(offset, length) {
-          return empty.subarray(offset, offset + length);
+        read(offset, target) {
+          const source = empty.subarray(offset, offset + target.byteLength);
+          target.set(source);
+          return source.byteLength;
         },
       }),
     }),

--- a/packages/runner/src/disk-worker.ts
+++ b/packages/runner/src/disk-worker.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+import { blockDevice, serveDevice } from "@lowland/kernel";
+import { closeSync, fstatSync, fsyncSync, openSync, readSync, writeSync } from "node:fs";
+import { parentPort, workerData } from "node:worker_threads";
+
+if (!parentPort) throw new Error("disk worker requires a parent port");
+
+let readonly = false;
+let file: number;
+try {
+  file = openSync(workerData.path, "r+");
+} catch {
+  readonly = true;
+  file = openSync(workerData.path, "r");
+}
+const { size: capacity } = fstatSync(file);
+
+serveDevice(
+  parentPort,
+  blockDevice({
+    capacity,
+    read(offset, target) {
+      let read = 0;
+      while (read < target.byteLength) {
+        const n = readSync(file, target, read, target.byteLength - read, offset + read);
+        if (n === 0) break;
+        read += n;
+      }
+      return read;
+    },
+    write: readonly
+      ? undefined
+      : (offset, data) => {
+          let written = 0;
+          while (written < data.byteLength) {
+            const n = writeSync(file, data, written, data.byteLength - written, offset + written);
+            if (n === 0) break;
+            written += n;
+          }
+          return written;
+        },
+    flush: readonly ? undefined : () => fsyncSync(file),
+    close() {
+      try {
+        if (!readonly) fsyncSync(file);
+      } finally {
+        closeSync(file);
+      }
+    },
+  }),
+);

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { blockDevice, bootMachine, consoleDevice, entropyDevice } from "@lowland/kernel";
-import { closeSync, fstatSync, fsync, openSync, readSync, writeSync } from "node:fs";
+import { bootMachine, consoleDevice, entropyDevice, workerDevice } from "@lowland/kernel";
 import { availableParallelism } from "node:os";
 import { Readable, Writable } from "node:stream";
 import { parseArgs } from "node:util";
+import { Worker } from "node:worker_threads";
 import { configureShares, type ShareArgument } from "./shares.ts";
 
 function assert(cond: unknown, message = "Assertion failed"): asserts cond {
@@ -136,45 +136,17 @@ if (args.entropy) {
 }
 
 for (const disk of args.disk) {
-  let readonly = false;
-  let file: number;
+  const worker = new Worker(new URL("./disk-worker.ts", import.meta.url), {
+    workerData: { path: disk },
+  });
   try {
-    file = openSync(disk, "r+");
-  } catch {
-    readonly = true;
-    file = openSync(disk, "r");
+    const device = await workerDevice(worker);
+    void device.closed.finally(() => worker.terminate()).catch(() => {});
+    devices.push(device);
+  } catch (error) {
+    await worker.terminate();
+    throw error;
   }
-  const { size } = fstatSync(file);
-
-  process.on("exit", () => closeSync(file));
-
-  devices.push(
-    blockDevice({
-      read: async (offset, array) => {
-        let n = 0;
-        while (n < array.byteLength) {
-          const read = readSync(file, array, n, array.byteLength - n, offset + n);
-          if (read === 0) break;
-          n += read;
-        }
-        return n;
-      },
-      write: readonly
-        ? undefined
-        : async (offset, data) => {
-            let n = 0;
-            while (n < data.byteLength) {
-              n += writeSync(file, data, n, data.byteLength - n, offset + n);
-            }
-            return n;
-          },
-      flush: () =>
-        new Promise<void>((resolve, reject) => {
-          fsync(file, (error) => (error ? reject(error) : resolve()));
-        }),
-      capacity: size,
-    }),
-  );
 }
 
 const machine = await bootMachine({

--- a/packages/runner/src/run.ts
+++ b/packages/runner/src/run.ts
@@ -150,15 +150,14 @@ for (const disk of args.disk) {
 
   devices.push(
     blockDevice({
-      read: async (offset, length) => {
-        const array = new Uint8Array(length);
+      read: async (offset, array) => {
         let n = 0;
         while (n < array.byteLength) {
           const read = readSync(file, array, n, array.byteLength - n, offset + n);
           if (read === 0) break;
           n += read;
         }
-        return array.subarray(0, n);
+        return n;
       },
       write: readonly
         ? undefined

--- a/packages/runner/tests/disk.test.ts
+++ b/packages/runner/tests/disk.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+function required_environment(name: string): string {
+  const value = process.env[name];
+  assert(value, `${name} is required`);
+  return value;
+}
+
+const runner = required_environment("LINUX_RUNNER_TEST_RUNNER");
+const root = required_environment("LINUX_RUNNER_TEST_ROOT_DISK");
+
+async function run_disk(disk: string, command: string) {
+  const child = spawn(runner, ["--cpus", "1", "--disk", root, "--disk", disk], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let output = "";
+  let sent = false;
+  const consume = (chunk: Buffer) => {
+    output += chunk.toString();
+    if (!sent && output.includes("~ #")) {
+      sent = true;
+      child.stdin.end(`${command}\n/sbin/poweroff -f\n`);
+    }
+  };
+  child.stdout.on("data", consume);
+  child.stderr.on("data", consume);
+  const timeout = setTimeout(() => child.kill("SIGKILL"), 60_000);
+  let result: { code: number | null; signal: NodeJS.Signals | null };
+  try {
+    result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", (code, signal) => resolve({ code, signal }));
+      },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  assert.deepEqual(result, { code: 0, signal: null }, output);
+  return output;
+}
+
+test("runner persists a virtio disk served by a filesystem worker", async (t) => {
+  const temporary = await mkdtemp(path.join(tmpdir(), "linux-runner-disk-"));
+  t.after(() => rm(temporary, { recursive: true, force: true }));
+  const disk = path.join(temporary, "disk.img");
+  await writeFile(disk, new Uint8Array(1024 * 1024));
+  const marker = "node-worker-virtio-round-trip";
+
+  await run_disk(
+    disk,
+    `until [ -b /dev/vdb ]; do sleep 0.1; done; printf '%s\\n' '${marker}' | dd of=/dev/vdb bs=512 conv=fsync 2>/dev/null`,
+  );
+  assert.equal((await readFile(disk, "utf8")).split("\n", 1)[0], marker);
+
+  const output = await run_disk(
+    disk,
+    "until [ -b /dev/vdb ]; do sleep 0.1; done; dd if=/dev/vdb bs=512 count=1 2>/dev/null | head -n 1",
+  );
+  assert.match(output, new RegExp(marker));
+});


### PR DESCRIPTION
## Summary

- add `workerDevice(endpoint)` and `serveDevice(endpoint, device)` so an entire virtio request chain can execute in a dedicated worker
- share kernel WebAssembly memory with the device worker while keeping queue publication and interrupts on the machine side
- use a small `Endpoint` abstraction that accepts browser Workers, MessagePorts, and Node worker endpoints
- make virtio device shutdown asynchronous and deterministic, including remote failures and optional block-storage cleanup
- consolidate browser/Node worker messaging primitives without moving persistence policy into the kernel package

## Protocol and lifecycle

The machine side sends queue configuration plus notifications. The worker reconstructs and owns each available chain directly over shared Wasm memory, then reports only the used length needed to publish completion. Reset is an atomic shared flag observed by in-flight worker chains; close drains active work before one-time cleanup. Errors are serialized across the endpoint and remain observable even if the worker fails immediately after initialization.

`Endpoint` deliberately models both EventTarget-style browser endpoints and EventEmitter-style Node workers. The simple documented path passes a Worker directly, while MessagePort remains available for callers that need separate setup metadata or several devices in one worker.

## Validation

- `pnpm typecheck`
- `pnpm --filter @lowland/kernel test` (24 passing)
- `git diff --check`