### PR TITLE
ci: Isolate scheduler-sensitive checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,11 @@ jobs:
         run: |
           installable=".#ciJobs.x86_64-linux.heavyChecks.${{ matrix.check }}"
           nix build --dry-run "$installable"
-          nix build --no-link --print-build-logs "$installable"
+          # Materialize a cached result first because Nix cannot --rebuild an
+          # output it has never registered, then execute this check regardless
+          # of whether a previous workflow attempt cached its success marker.
+          nix build --no-link "$installable"
+          nix build --rebuild --no-link --print-build-logs "$installable"
 
   deploy-site:
     name: Deploy site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,8 @@ jobs:
           nix eval --json '.#ciJobs.x86_64-linux' --apply '
             jobs:
             let
-              describe = builtins.mapAttrs (
+              describeBuilds = builtins.mapAttrs (_: derivation: { drv = derivation.drvPath; });
+              describeChecks = builtins.mapAttrs (
                 _: derivation:
                 {
                   drv = derivation.drvPath;
@@ -57,8 +58,8 @@ jobs:
               );
             in
             {
-              builds = describe jobs.builds;
-              checks = describe jobs.checks;
+              builds = describeBuilds jobs.builds;
+              checks = describeChecks jobs.checks;
             }
           ' > "$checks_file"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,27 @@ on:
       - published
 
 jobs:
+  plan:
+    name: Plan checks
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      heavy-checks: ${{ steps.plan.outputs.heavy-checks }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v35
+      - id: plan
+        name: Discover heavy checks
+        run: |
+          checks=$(nix eval --json '.#ciJobs.x86_64-linux.heavyChecks' \
+            --apply 'checks: builtins.attrNames checks')
+          echo "heavy-checks=$(jq --compact-output '{check: .}' <<< "$checks")" \
+            >> "$GITHUB_OUTPUT"
+
   build:
+    name: Build packages and checks
+    needs: plan
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -25,15 +45,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           checks_file="$RUNNER_TEMP/checks.json"
-          nix eval --json '.#checks.x86_64-linux' --apply '
-            checks:
-            builtins.mapAttrs (
-              _: check:
-              {
-                drv = check.drvPath;
-                outputs = map (output: (builtins.getAttr output check).outPath) check.outputs;
-              }
-            ) checks
+          nix eval --json '.#ciJobs.x86_64-linux' --apply '
+            jobs:
+            let
+              describe = builtins.mapAttrs (
+                _: derivation:
+                {
+                  drv = derivation.drvPath;
+                  outputs = map (output: (builtins.getAttr output derivation).outPath) derivation.outputs;
+                }
+              );
+            in
+            {
+              builds = describe jobs.builds;
+              checks = describe jobs.checks;
+            }
           ' > "$checks_file"
 
           status() {
@@ -47,11 +73,16 @@ jobs:
               >/dev/null
           }
 
-          mapfile -t checks < <(jq --raw-output 'keys[]' "$checks_file")
+          mapfile -t builds < <(jq --raw-output '.builds | keys[]' "$checks_file")
+          mapfile -t checks < <(jq --raw-output '.checks | keys[]' "$checks_file")
           installables=()
+          for build in "${builds[@]}"; do
+            drv=$(jq --raw-output --arg build "$build" '.builds[$build].drv' "$checks_file")
+            installables+=("$drv^*")
+          done
           for check in "${checks[@]}"; do
             status "$check" pending "Build in progress"
-            drv=$(jq --raw-output --arg check "$check" '.[$check].drv' "$checks_file")
+            drv=$(jq --raw-output --arg check "$check" '.checks[$check].drv' "$checks_file")
             installables+=("$drv^*")
           done
 
@@ -67,7 +98,7 @@ jobs:
 
           for check in "${checks[@]}"; do
             mapfile -t outputs < <(
-              jq --raw-output --arg check "$check" '.[$check].outputs[]' "$checks_file"
+              jq --raw-output --arg check "$check" '.checks[$check].outputs[]' "$checks_file"
             )
             state=success
             description="Build passed"
@@ -95,9 +126,35 @@ jobs:
           path: npm-packages/*.tgz
           if-no-files-found: error
 
+  heavy-check:
+    name: Heavy check / ${{ matrix.check }}
+    needs:
+      - plan
+      - build
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.heavy-checks) }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: cachix/cachix-action@v17
+        with:
+          name: linuxwasm
+          authToken: "${{secrets.CACHIX_AUTH_TOKEN}}"
+      - name: Build isolated check
+        run: |
+          installable=".#ciJobs.x86_64-linux.heavyChecks.${{ matrix.check }}"
+          nix build --dry-run "$installable"
+          nix build --no-link --print-build-logs "$installable"
+
   deploy-site:
     name: Deploy site
-    needs: build
+    needs:
+      - build
+      - heavy-check
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'tombl/distro') || github.event.pull_request.head.repo.full_name == 'tombl/distro'
     runs-on: ubuntu-24.04
     steps:
@@ -141,7 +198,9 @@ jobs:
 
   stage-npm:
     name: Stage packages on npm
-    needs: build
+    needs:
+      - build
+      - heavy-check
     if: github.event_name == 'release' && github.repository == 'tombl/distro'
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,12 +148,7 @@ jobs:
       - name: Build isolated check
         run: |
           installable=".#ciJobs.x86_64-linux.heavyChecks.${{ matrix.check }}"
-          nix build --dry-run "$installable"
-          # Materialize a cached result first because Nix cannot --rebuild an
-          # output it has never registered, then execute this check regardless
-          # of whether a previous workflow attempt cached its success marker.
-          nix build --no-link "$installable"
-          nix build --rebuild --no-link --print-build-logs "$installable"
+          nix build --no-link --print-build-logs "$installable"
 
   deploy-site:
     name: Deploy site

--- a/distro/basic-init/package.nix
+++ b/distro/basic-init/package.nix
@@ -62,6 +62,7 @@ let
 
   namedSemaphoreCheck = vm-test.vmTest {
     name = "basic-init-named-semaphore";
+    heavy = true;
     initramfs = vm-test.mkInitramfs {
       name = "basic-init-named-semaphore";
       init = "${buildInit "basic-init-named-semaphore" "tests/named-semaphore.c"}/bin/init";

--- a/distro/npm/linux-guest/package.nix
+++ b/distro/npm/linux-guest/package.nix
@@ -101,6 +101,7 @@ let
   integration = pkgs.stdenvNoCC.mkDerivation {
     pname = "linux-guest-integration-test";
     version = "0.0.0";
+    passthru.ci.heavy = true;
     src = ../../..;
     env.CI = "true";
     pnpmDeps = node-workspace.deps;

--- a/distro/npm/playwright.nix
+++ b/distro/npm/playwright.nix
@@ -46,25 +46,30 @@ in
       project,
       suite,
     }:
-    pkgs.runCommand name { nativeBuildInputs = [ pkgs.nodejs ]; } ''
-      export TMPDIR="$NIX_BUILD_TOP/tmp"
-      export HOME="$TMPDIR/home"
-      export XDG_CACHE_HOME="$TMPDIR/cache"
-      export XDG_CONFIG_HOME="$TMPDIR/config"
-      mkdir -p "$HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
+    pkgs.runCommand name
+      {
+        nativeBuildInputs = [ pkgs.nodejs ];
+        passthru.ci.heavy = true;
+      }
+      ''
+        export TMPDIR="$NIX_BUILD_TOP/tmp"
+        export HOME="$TMPDIR/home"
+        export XDG_CACHE_HOME="$TMPDIR/cache"
+        export XDG_CONFIG_HOME="$TMPDIR/config"
+        mkdir -p "$HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
 
-      export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json
-      export FONTCONFIG_FILE=${fontconfig}
-      export LIBGL_ALWAYS_SOFTWARE=1
-      export LIBGL_DRIVERS_PATH=${pkgs.mesa}/lib/dri
-      export PLAYWRIGHT_BROWSERS_PATH=${browsersFor project}
-      export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu-24.04
-      export PLAYWRIGHT_OUTPUT_DIR="$TMPDIR/test-results"
-      export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
-      export WEBKIT_DISABLE_DMABUF_RENDERER=1
+        export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json
+        export FONTCONFIG_FILE=${fontconfig}
+        export LIBGL_ALWAYS_SOFTWARE=1
+        export LIBGL_DRIVERS_PATH=${pkgs.mesa}/lib/dri
+        export PLAYWRIGHT_BROWSERS_PATH=${browsersFor project}
+        export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu-24.04
+        export PLAYWRIGHT_OUTPUT_DIR="$TMPDIR/test-results"
+        export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+        export WEBKIT_DISABLE_DMABUF_RENDERER=1
 
-      cd ${suite}
-      node node_modules/@playwright/test/cli.js test --project=${project} --reporter=line
-      touch $out
-    '';
+        cd ${suite}
+        node node_modules/@playwright/test/cli.js test --project=${project} --reporter=line
+        touch $out
+      '';
 }

--- a/distro/npm/runner/package.nix
+++ b/distro/npm/runner/package.nix
@@ -103,6 +103,7 @@ let
   integration = pkgs.stdenvNoCC.mkDerivation {
     pname = "linux-runner-integration-test";
     version = "0.0.0";
+    passthru.ci.heavy = true;
     src = ../../..;
     env.CI = "true";
     pnpmDeps = node-workspace.deps;

--- a/distro/vm-test/package.nix
+++ b/distro/vm-test/package.nix
@@ -47,10 +47,12 @@ let
       initramfs,
       disk ? null,
       cpus ? 1,
+      heavy ? false,
     }:
     pkgs.runCommand "vm-test-${name}"
       {
         nativeBuildInputs = [ pkgs.nodejs ];
+        passthru.ci.heavy = heavy;
       }
       ''
         ${lib.optionalString (disk != null) ''

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,23 @@
         }
       );
 
+      # All validations remain conventional flake checks. This view only gives
+      # CI enough semantic information to isolate scheduler-sensitive checks;
+      # derivations opt in with passthru.ci.heavy rather than naming conventions.
+      ciJobs = eachSystem (
+        { pkgs, ... }:
+        let
+          system = pkgs.stdenv.hostPlatform.system;
+          checks = self.checks.${system};
+          isHeavy = _name: check: check.ci.heavy or false;
+        in
+        {
+          builds = self.packages.${system};
+          checks = lib.filterAttrs (name: check: !(isHeavy name check)) checks;
+          heavyChecks = lib.filterAttrs isHeavy checks;
+        }
+      );
+
       formatter = eachSystem ({ pkgs, ... }: import ./formatter.nix { inherit pkgs; });
 
       devShells = eachSystem (

--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -128,10 +128,14 @@ globalThis.remoteMemoryMetadata = () =>
         "MARKER=remote-vm-environ sleep 30 &",
         "pid=$!",
         "attempt=0",
-        "while [ $attempt -lt 100 ]; do",
+        "while [ $attempt -lt 500 ]; do",
         "  cmdline=$(tr '\\000' ' ' < /proc/$pid/cmdline)",
         '  [ "$cmdline" = "sleep 30 " ] && break',
         "  attempt=$((attempt+1))",
+        // Reading /proc does not block. Yield the single guest CPU so the
+        // background child can reach execve instead of exhausting a retry
+        // count while it still has the parent shell's command line.
+        "  sleep 0.01",
         "done",
         "environ=$(tr '\\000' '\\n' < /proc/$pid/environ)",
         "auxv_size=$(wc -c < /proc/$pid/auxv)",
@@ -159,10 +163,14 @@ globalThis.runRemoteMemoryLifecycleBatch = async (batch, iterations) => {
     `  MARKER=remote-vm-lifecycle-${batch}-$i sleep 30 &`,
     "  pid=$!",
     "  attempt=0",
-    "  while [ $attempt -lt 100 ]; do",
+    "  while [ $attempt -lt 500 ]; do",
     "    cmdline=$(tr '\\000' ' ' < /proc/$pid/cmdline)",
     '    [ "$cmdline" = "sleep 30 " ] && break',
     "    attempt=$((attempt+1))",
+    // This is a readiness wait, not a throughput assertion. Without a
+    // blocking operation the observer can win every timeslice and consume
+    // all retries before the child changes its /proc identity at execve.
+    "    sleep 0.01",
     "  done",
     "  environ=$(tr '\\000' '\\n' < /proc/$pid/environ | grep '^MARKER=')",
     "  auxv_size=$(wc -c < /proc/$pid/auxv)",


### PR DESCRIPTION
## Summary

- keep every validation in the standard flake `checks` namespace
- classify scheduler-sensitive derivations with `passthru.ci.heavy`
- build all packages and ordinary checks together with normal Nix parallelism
- fan heavy checks out to isolated GitHub runners after the build/cache barrier
- harden the remote-memory process readiness wait

## Root cause

The previous workflow ran browser and integration derivations together on a four-core runner. Scheduler starvation stretched a roughly 35-second WebKit suite beyond four minutes and caused unrelated guest operations to time out. Local pressure testing also exposed the named-semaphore VM check as scheduler-sensitive. Limiting `--cores` was not the fix: it is builder advice rather than machine isolation and can make time-sensitive suites slower.

## Design

All validations remain conventional flake checks. A small `ciJobs` view filters them by `passthru.ci.heavy`. The plan job derives the matrix dynamically, the build job completes packages and non-heavy checks first, and each heavy matrix entry builds exactly one check on its own runner. Cachix carries package prerequisites across the dependency barrier.

## Validation

- `nix flake check --no-build`
- parallel local build of all 46 package outputs and 84 non-heavy checks
- all 10 heavy checks built independently locally
- 92/92 Linux guest integration tests passed; 9/9 runner integration tests passed
- `nix run nixpkgs#actionlint -- .github/workflows/ci.yml`
- `nix fmt -- --ci`
- `git diff --check`
- the isolation design passed three complete GitHub workflow attempts, with 30/30 heavy matrix jobs green

[Workflow run and reruns](https://github.com/tombl/distro/actions/runs/31658173002)