### PR TITLE
kernel: refresh shared memory on worker handoff

### DIFF
--- a/distro/basic-init/package.nix
+++ b/distro/basic-init/package.nix
@@ -60,6 +60,17 @@ let
     cpus = 2;
   };
 
+  posixSpawnStressInitramfs = vm-test.mkInitramfs {
+    name = "basic-init-posix-spawn-stress";
+    init = "${buildInit "basic-init-posix-spawn-stress" "tests/posix-spawn-stress.c"}/bin/init";
+  };
+
+  posixSpawnStressCheck = vm-test.vmTest {
+    name = "basic-init-posix-spawn-stress";
+    initramfs = posixSpawnStressInitramfs;
+    heavy = true;
+  };
+
   namedSemaphoreCheck = vm-test.vmTest {
     name = "basic-init-named-semaphore";
     heavy = true;
@@ -156,7 +167,7 @@ let
 in
 (buildInitWith "basic-init" "init.c" "").overrideAttrs (old: {
   passthru = (old.passthru or { }) // {
-    inherit remoteMemoryInitramfs schedulerHandoffInitramfs;
+    inherit posixSpawnStressInitramfs remoteMemoryInitramfs schedulerHandoffInitramfs;
     checks = {
       auxv = check "auxv";
       boot = check "boot";
@@ -189,6 +200,7 @@ in
       memory-abi = memoryAbiCheck;
       named-semaphore = namedSemaphoreCheck;
       proc-self-mem = check "proc-self-mem";
+      posix-spawn-stress = posixSpawnStressCheck;
       pty = check "pty";
       remote-memory = remoteMemoryCheck;
       scheduler-handoff = schedulerHandoffCheck;

--- a/distro/basic-init/tests/posix-spawn-stress.c
+++ b/distro/basic-init/tests/posix-spawn-stress.c
@@ -1,0 +1,125 @@
+#define _GNU_SOURCE
+
+#include "test.h"
+
+#include <pthread.h>
+#include <spawn.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+enum {
+	iterations = 256,
+	growth_bytes = 16 * 1024 * 1024,
+	environment_count = 32,
+	environment_value_bytes = 2048,
+};
+
+struct spawn_context {
+	char *environment[environment_count + 1];
+	char *path;
+	char *cwd;
+	char *growth;
+	pthread_mutex_t mutex;
+	pthread_cond_t condition;
+	int memory_ready;
+};
+
+static void *spawn_stress(void *argument)
+{
+	struct spawn_context *context = argument;
+
+	/* The InitMessage carrying this worker's memory is posted before the main
+	 * worker grows it. Waiting here also makes the old wrapper observable
+	 * before any high-memory pathname or environment pointer is consumed. */
+	if (pthread_mutex_lock(&context->mutex))
+		test_fail("lock spawn readiness mutex");
+	while (!context->memory_ready)
+		if (pthread_cond_wait(&context->condition, &context->mutex))
+			test_fail("wait for grown user memory");
+	if (pthread_mutex_unlock(&context->mutex))
+		test_fail("unlock spawn readiness mutex");
+
+	for (int i = 0; i < iterations; i++) {
+		char *argv[] = { context->path, "--child", NULL };
+		posix_spawn_file_actions_t actions;
+		pid_t pid;
+		int error;
+		int actions_initialized;
+		int status;
+
+		error = posix_spawn_file_actions_init(&actions);
+		actions_initialized = !error;
+		if (!error)
+			error = posix_spawn_file_actions_addchdir_np(&actions,
+							       context->cwd);
+		if (!error)
+			error = posix_spawn(&pid, context->path, &actions, NULL,
+					    argv, context->environment);
+		if (actions_initialized)
+			posix_spawn_file_actions_destroy(&actions);
+		if (error) {
+			errno = error;
+			printf("posix-spawn-stress iteration=%d pages=%zu path=%p cwd=%p argv=%p envp=%p\n",
+			       i, (size_t)__builtin_wasm_memory_size(0),
+			       context->path, context->cwd, argv,
+			       context->environment);
+			test_perror("posix_spawn high-memory child");
+		}
+		if (waitpid(pid, &status, 0) == -1)
+			test_perror("waitpid spawn child");
+		if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+			test_fail("spawn child did not exit successfully");
+	}
+
+	/* Keep the forced growth observable to the optimizer through the soak. */
+	if ((unsigned char)context->growth[growth_bytes - 1] != 0x5a)
+		test_fail("growth buffer changed");
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	pthread_t thread;
+	struct spawn_context context = { 0 };
+	void *result;
+
+	if (argc == 2 && !strcmp(argv[1], "--child"))
+		return 0;
+	if (pthread_mutex_init(&context.mutex, NULL) ||
+	    pthread_cond_init(&context.condition, NULL))
+		test_fail("initialize spawn synchronization");
+	if (pthread_create(&thread, NULL, spawn_stress, &context) != 0)
+		test_fail("create spawn stress thread");
+
+	/* Grow only after pthread_create has posted the child's InitMessage, then
+	 * allocate every execve pointer beyond the child's captured old end. */
+	context.growth = malloc(growth_bytes);
+	if (!context.growth)
+		test_perror("allocate growth buffer");
+	memset(context.growth, 0x5a, growth_bytes);
+	context.path = strdup("/init");
+	context.cwd = strdup("/");
+	if (!context.path || !context.cwd)
+		test_perror("allocate spawn paths");
+	for (int i = 0; i < environment_count; i++) {
+		context.environment[i] = malloc(environment_value_bytes);
+		if (!context.environment[i])
+			test_perror("allocate spawn environment");
+		int prefix = snprintf(context.environment[i], environment_value_bytes,
+				      "STRESS_%d=", i);
+		memset(context.environment[i] + prefix, 'a' + i % 26,
+		       environment_value_bytes - prefix - 1);
+		context.environment[i][environment_value_bytes - 1] = 0;
+	}
+	if (pthread_mutex_lock(&context.mutex))
+		test_fail("lock spawn publication mutex");
+	context.memory_ready = 1;
+	if (pthread_cond_signal(&context.condition) ||
+	    pthread_mutex_unlock(&context.mutex))
+		test_fail("publish grown user memory");
+	if (pthread_join(thread, &result) != 0 || result)
+		test_fail("join spawn stress thread");
+	test_pass();
+}

--- a/distro/npm/browser-tests.nix
+++ b/distro/npm/browser-tests.nix
@@ -24,11 +24,13 @@ let
     cp ${site.package}/static/*/opfs-disk-worker.js $out/opfs-disk-worker.js
     cp ${basic-init.schedulerHandoffInitramfs} $out/scheduler-handoff.cpio
     cp ${basic-init.remoteMemoryInitramfs} $out/remote-vm.cpio
+    cp ${basic-init.posixSpawnStressInitramfs} $out/posix-spawn-stress.cpio
     cp ${source}/server.js $out/server.js
     cp ${linux-guest.package.checks.tests.assets}/rootfs.erofs $out/rootfs.erofs
     mkdir $out/tests
     cp ${source}/tests/boot.spec.js $out/tests/
     cp ${source}/tests/opfs-disk.spec.js $out/tests/
+    cp ${source}/tests/posix-spawn-stress.spec.js $out/tests/
     cp ${source}/tests/remote-memory.spec.js $out/tests/
     cp ${source}/tests/spawn-stress.spec.js $out/tests/
     cp ${source}/tests/virtio-fs.spec.js $out/tests/

--- a/packages/browser-tests/app.js
+++ b/packages/browser-tests/app.js
@@ -249,6 +249,8 @@ globalThis.schedulerHandoffStress = () => runInitramfs("/scheduler-handoff.cpio"
 
 globalThis.remoteMemoryProtocol = () => runInitramfs("/remote-vm.cpio", 2);
 
+globalThis.posixSpawnHandoffStress = () => runInitramfs("/posix-spawn-stress.cpio", 1);
+
 globalThis.opfsVirtioFileSystem = async () => {
   const storage = await navigator.storage.getDirectory();
   await storage.removeEntry("virtio-fs-test", { recursive: true }).catch(() => {});

--- a/packages/browser-tests/server.js
+++ b/packages/browser-tests/server.js
@@ -60,6 +60,8 @@ const server = createServer(async (request, response) => {
         path = await build("basic-init.schedulerHandoffInitramfs");
       } else if (relative === "remote-vm.cpio") {
         path = await build("basic-init.remoteMemoryInitramfs");
+      } else if (relative === "posix-spawn-stress.cpio") {
+        path = await build("basic-init.posixSpawnStressInitramfs");
       }
     } catch (error) {
       console.error(`failed to build ${relative}:`, error.stderr ?? error);

--- a/packages/browser-tests/tests/posix-spawn-stress.spec.js
+++ b/packages/browser-tests/tests/posix-spawn-stress.spec.js
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("hands grown user memory to posix_spawn children", async ({ page }) => {
+  test.setTimeout(180_000);
+  page.on("console", (message) => console.log(`[browser] ${message.text()}`));
+  page.on("pageerror", (error) => console.error(`[browser] ${error.stack ?? error}`));
+
+  await page.goto("/");
+  await expect
+    .poll(() => page.evaluate(() => typeof globalThis.posixSpawnHandoffStress))
+    .toBe("function");
+  await page.evaluate(() => globalThis.posixSpawnHandoffStress());
+});

--- a/packages/kernel/src/virtio/remote.ts
+++ b/packages/kernel/src/virtio/remote.ts
@@ -332,6 +332,7 @@ export function serveDevice(endpoint: Endpoint, device: VirtioDevice): void {
       switch (message?.type) {
         case "bind":
           assert(!connected, "virtio device is already bound");
+          message.memory.grow(0);
           control = new Int32Array(message.control);
           connected = connect_virtio_device(device, {
             memory: message.memory,

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -392,10 +392,11 @@ function start({
   user: initial_user_context,
   user_copy_status,
 }: InitMessage) {
-  // This worker may register after another isolate has grown the shared user
-  // memory. V8 can retain the fixed-length buffer wrapper captured in the
-  // InitMessage until its asynchronous refresh runs; grow(0) refreshes it
-  // synchronously before any user-memory view is constructed.
+  // Refresh every WebAssembly.Memory received across a worker boundary
+  // immediately, including any future additions to InitMessage. Chromium can
+  // retain the fixed-length buffer wrapper captured before another isolate
+  // grows it; grow(0) refreshes the wrapper before constructing any views.
+  memory.grow(0);
   initial_user_context?.memory.grow(0);
 
   let user_context = initial_user_context;

--- a/packages/kernel/src/worker.ts
+++ b/packages/kernel/src/worker.ts
@@ -392,6 +392,12 @@ function start({
   user: initial_user_context,
   user_copy_status,
 }: InitMessage) {
+  // This worker may register after another isolate has grown the shared user
+  // memory. V8 can retain the fixed-length buffer wrapper captured in the
+  // InitMessage until its asynchronous refresh runs; grow(0) refreshes it
+  // synchronously before any user-memory view is constructed.
+  initial_user_context?.memory.grow(0);
+
   let user_context = initial_user_context;
   if (user_copy_status) {
     assert(user_context);


### PR DESCRIPTION
## What changed

- synchronously refresh every `WebAssembly.Memory` received in a kernel worker `InitMessage`, covering both kernel and userspace memory
- refresh memory immediately when a remote virtio worker handles its `bind` message
- document that future cross-worker memory handoffs must refresh immediately
- add a focused guest regression that grows userspace after `pthread_create()`, places `posix_spawn()` inputs above the worker's captured old end, and executes 256 children
- run the reproducer through the Chromium browser-test package and expose it as a standalone heavy VM check

## Root cause

Chromium/V8 can retain the fixed-length `SharedArrayBuffer` wrapper captured when a shared `WebAssembly.Memory` is posted to another worker and then grown before the receiver handles it. Valid addresses in the new pages subsequently fail typed-array or `DataView` construction.

In the userspace path, checked uaccess translates that host failure into bytes not copied, Linux reports `EFAULT`, and musl returns it from `posix_spawn()`. Kernel-memory imports and remote virtio queue traversal can fail with the same stale-wrapper mechanism.

A zero-page grow refreshes the receiving isolate's wrapper synchronously before its first access.

## Impact

This prevents intermittent process-spawn failures and the equivalent kernel-memory and remote-virtio handoff failures in Chromium without retrying operations or weakening `EFAULT` semantics.

## Validation

- minimal Chromium established-worker probe: 0/100 stale wrappers after later growth
- generic post-then-grow handoff: 100/100 failures before refresh, 0/100 after
- real kernel `InitMessage` probe: 100/100 failures before refresh, 0/100 after
- real remote-virtio packed-queue probe: 100/100 failures before refresh, 0/100 after
- focused packaged Chromium guest regression: 5 consecutive passes
- `npm --prefix packages/kernel run check`
- `npm --prefix packages/kernel test` (25/25)
- Node VM basic-init check
- `git diff --check`

Stacked on #148 because that CI isolation work exposed the existing runtime fault.