### PR TITLE
site: fall back when persistent storage is unavailable

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -97,7 +97,7 @@
       import { BrowserFS } from "@tombl/linux-guest/browser";
       import { serveGuest } from "./static/__ASSET_DIRECTORY__/bridge-client.js";
 
-      const bootMode = "__BOOT_MODE__";
+      let bootMode = "__BOOT_MODE__";
       if (
         "serviceWorker" in navigator &&
         (bootMode === "live" || !navigator.serviceWorker.controller)
@@ -126,6 +126,14 @@
 
       if (!window.crossOriginIsolated) {
         term.write("Error: not cross origin isolated\n");
+      }
+
+      let opfs;
+      try {
+        opfs = await navigator.storage.getDirectory();
+      } catch (error) {
+        console.warn("Persistent storage is unavailable; continuing in live-only mode", error);
+        bootMode = "live";
       }
 
       const { cmdline = "" } = parameters;
@@ -237,8 +245,7 @@
         };
       }
 
-      async function openInstallDisk({ requireFilesystem }) {
-        const directory = await navigator.storage.getDirectory();
+      async function openInstallDisk({ directory, requireFilesystem }) {
         const handle = await directory.getFileHandle("root.ext4", { create: true });
         const file = await handle.getFile();
         const superblock = 1024;
@@ -279,14 +286,17 @@
       const disk =
         bootMode === "live"
           ? await openLiveDisk()
-          : await openInstallDisk({ requireFilesystem: true });
+          : await openInstallDisk({ directory: opfs, requireFilesystem: true });
       // A ?live=1 recovery boot alongside an existing installation must not
       // expose two LOWLAND_ROOT disks to the general-purpose agent. Only an
       // unformatted device is attached to a live installer.
       const installDisk =
-        bootMode === "live" ? await openInstallDisk({ requireFilesystem: false }) : undefined;
-      const opfs = await navigator.storage.getDirectory();
-      const bootDirectory = await opfs.getDirectoryHandle("boot", { create: true });
+        bootMode === "live" && opfs
+          ? await openInstallDisk({ directory: opfs, requireFilesystem: false })
+          : undefined;
+      const bootDirectory = opfs
+        ? await opfs.getDirectoryHandle("boot", { create: true })
+        : undefined;
       const guest = await spawnGuest({
         root: bootMode === "live" ? blockDevice(disk) : disk,
         bootConsole: bootOut,
@@ -294,16 +304,20 @@
         // part of the facade contract.
         cpus: 1,
         network,
-        cmdline: `${bootMode === "live" ? "lowland.root.overlay=tmpfs " : ""}${cmdline.replace(/\+/g, " ")}`,
+        cmdline: `${bootMode === "live" ? "lowland.root.overlay=tmpfs " : ""}${installDisk ? "lowland.install=1 " : ""}${cmdline.replace(/\+/g, " ")}`,
         devices: [
           ttyConsole,
           ...(installDisk ? [installDisk] : []),
           entropyDevice(),
-          fileSystemDevice(new BrowserFS(bootDirectory), { tag: "boot", cache: false }),
+          ...(bootDirectory
+            ? [fileSystemDevice(new BrowserFS(bootDirectory), { tag: "boot", cache: false })]
+            : []),
         ],
       });
-      await guest.fs.mkdir("/boot", { recursive: true });
-      await guest.mount("boot", "/boot", { type: "virtiofs" });
+      if (bootDirectory) {
+        await guest.fs.mkdir("/boot", { recursive: true });
+        await guest.mount("boot", "/boot", { type: "virtiofs" });
+      }
 
       // Service-worker and BroadcastChannel state is partitioned by site, so
       // only production low.land can provide its sibling guest-origin family.

--- a/apps/site/service-worker.js
+++ b/apps/site/service-worker.js
@@ -57,14 +57,8 @@ async function serve(event) {
         "Cross-Origin-Resource-Policy": "same-origin",
       },
     });
-  } catch (error) {
-    if (
-      error instanceof DOMException &&
-      ["NotFoundError", "TypeMismatchError"].includes(error.name)
-    ) {
-      return fetch(request);
-    }
-    throw error;
+  } catch {
+    return fetch(request);
   }
 }
 

--- a/distro/site/init.sh
+++ b/distro/site/init.sh
@@ -28,7 +28,7 @@ printf '%-14s%s\n' "/'\\_   _/\`\\" "${label}shell${reset}    sh"
 printf '%-14s%s\n' '\___)=(___/' "${label}apk${reset}      add curl jq sqlite3, and more"
 echo
 
-if [ ! -e /etc/lowland-installed ]; then
+if [ ! -e /etc/lowland-installed ] && grep -qw 'lowland.install=1' /proc/cmdline; then
   echo "Run ${bold}install-lowland${reset} to install this machine locally."
   echo
 fi

--- a/packages/browser-tests/tests/site-live.spec.js
+++ b/packages/browser-tests/tests/site-live.spec.js
@@ -30,6 +30,7 @@ test("boots and formats a blank persistent disk into the canonical system", asyn
 
   await page.goto("/?webgl=0");
   const { input, terminal } = await waitForGuest(page);
+  await expect(terminal).toContainText("Run install-lowland to install this machine locally.");
   await input.pressSequentially(
     "printf 'overlay-%s\\n' write-ok > /live-write-test; cat /live-write-test",
   );
@@ -68,4 +69,34 @@ test("boots and formats a blank persistent disk into the canonical system", asyn
 
   expect(rootfsRequests).toHaveLength(liveRootfsRequests);
   expect(rootfsRequests.some((headers) => headers.range?.startsWith("bytes="))).toBe(true);
+});
+
+test("falls back to live-only mode when persistent storage is unavailable", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(StorageManager.prototype, "getDirectory", {
+      configurable: true,
+      value: async () => {
+        throw new DOMException("Security error when calling GetDirectory", "SecurityError");
+      },
+    });
+  });
+
+  const dialogs = [];
+  page.on("dialog", async (dialog) => {
+    dialogs.push(dialog.message());
+    await dialog.dismiss();
+  });
+  await page.goto("/?webgl=0");
+
+  const terminal = page.locator(".xterm-rows");
+  await expect(terminal).toContainText("root@lowland", { timeout: 30_000 });
+  await expect(terminal).not.toContainText("install-lowland");
+
+  const input = page.locator(".xterm-helper-textarea");
+  await input.pressSequentially(
+    "! grep -qw 'lowland.install=1' /proc/cmdline && ! grep -q ' /boot virtiofs ' /proc/mounts && printf 'live-only-%s\\n' ready",
+  );
+  await input.press("Enter");
+  await expect(terminal).toContainText("live-only-ready");
+  expect(dialogs).toEqual([]);
 });


### PR DESCRIPTION
## Summary

- fall back to the immutable live system when OPFS is unavailable
- omit the persistent install disk and `/boot` mount in live-only mode
- advertise `install-lowland` only when the install disk was attached
- make service-worker OPFS failures fall through to network resources

## Why

Firefox disables OPFS in private browsing, where `navigator.storage.getDirectory()` rejects and previously surfaced through the site's global `alert()` handler. The site can still run its immutable live image in that environment, but cannot offer persistence or installation.

## Validation

- `nix build .#browser-tests.checks.site-live --no-link --print-build-logs` (2 passed)
- `nix build .#browser-tests.checks.service-worker --no-link --print-build-logs` (1 passed)
- `nix fmt -- --ci ...`
- `git diff --check`